### PR TITLE
Add unit test coverage for logging and restlogger

### DIFF
--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,36 @@
+package logging_test
+
+import (
+	"github.com/Azure/aks-middleware/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetMethodInfo", func() {
+	Context("when method is GET and URL has nested resource type", func() {
+		It("returns the correct method info for a READ operation", func() {
+			method := "GET"
+			url := "https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name?api-version=version"
+			expected := "GET storageAccounts - READ"
+			Expect(logging.GetMethodInfo(method, url)).To(Equal(expected))
+		})
+	})
+
+	Context("when method is GET and URL has top-level resource type", func() {
+		It("returns the correct method info for a LIST operation", func() {
+			method := "GET"
+			url := "https://management.azure.com/subscriptions/sub_id/resourceGroups?api-version=version"
+			expected := "GET resourceGroups - LIST"
+			Expect(logging.GetMethodInfo(method, url)).To(Equal(expected))
+		})
+	})
+
+	Context("when method is not GET", func() {
+		It("returns the correct method info without operation type", func() {
+			method := "POST"
+			url := "https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version"
+			expected := "POST storageAccounts"
+			Expect(logging.GetMethodInfo(method, url)).To(Equal(expected))
+		})
+	})
+})

--- a/restlogger/restlogger_test.go
+++ b/restlogger/restlogger_test.go
@@ -1,0 +1,83 @@
+package restlogger_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/aks-middleware/logging"
+	"github.com/Azure/aks-middleware/restlogger"
+	log "log/slog"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRestlogger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Restlogger Suite")
+}
+
+var _ = Describe("LoggingRoundTripper", func() {
+	var (
+		mockServer *httptest.Server
+		logger     *log.Logger
+		logBuffer  bytes.Buffer
+		client     *http.Client
+	)
+
+	BeforeEach(func() {
+		logger = log.New(log.NewTextHandler(&logBuffer, nil))
+		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("mock response"))
+		}))
+		client = &http.Client{
+			Transport: &restlogger.LoggingRoundTripper{
+				Proxied: http.DefaultTransport,
+				Logger:  logger,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		mockServer.Close()
+	})
+
+	Context("when making a successful request", func() {
+		It("logs the request and response details", func() {
+			req, _ := http.NewRequest("GET", mockServer.URL, nil)
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			logOutput := logBuffer.String()
+			Expect(logOutput).To(ContainSubstring("finished call"))
+			Expect(logOutput).To(ContainSubstring("GET"))
+			Expect(logOutput).To(ContainSubstring("200"))
+			Expect(logOutput).To(ContainSubstring(mockServer.URL))
+		})
+	})
+
+	Context("when the server returns an error", func() {
+		BeforeEach(func() {
+			mockServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "mock error", http.StatusInternalServerError)
+			})
+		})
+
+		It("logs the error", func() {
+			req, _ := http.NewRequest("POST", mockServer.URL, nil)
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+
+			logOutput := logBuffer.String()
+			Expect(logOutput).To(ContainSubstring("error finishing call"))
+			Expect(logOutput).To(ContainSubstring("POST"))
+			Expect(logOutput).To(ContainSubstring("500"))
+			Expect(logOutput).To(ContainSubstring(mockServer.URL))
+		})
+	})
+})


### PR DESCRIPTION
Adds unit test coverage for recent changes in logging and REST API call logging functionalities.

- **Introduces unit tests for `logging/logging.go`**: 
  - Tests the `GetMethodInfo` function with various HTTP methods and URL patterns to ensure accurate logging information is generated for both READ and LIST operations.
- **Implements unit tests for `restlogger/restlogger.go`**: 
  - Validates the `RoundTrip` method of `LoggingRoundTripper`, ensuring proper logging of HTTP request and response details, including error scenarios.
  - Utilizes a mock HTTP server to simulate responses and errors for comprehensive testing.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Azure/aks-middleware/pull/7?shareId=51229068-c7d2-401a-9b1f-805a478a457b).