### PR TITLE
Update logging to use UnifiedLogger

### DIFF
--- a/autologger/autologger.go
+++ b/autologger/autologger.go
@@ -7,39 +7,30 @@ import (
 	"context"
 	"fmt"
 
-	log "log/slog"
-
 	"github.com/Azure/aks-middleware/requestid"
+	"github.com/Azure/aks-middleware/unifiedlogger"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
-func InterceptorLogger(logger *log.Logger) logging.Logger {
+func InterceptorLogger(logger *unifiedlogger.LoggerWrapper) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		// fmt.Println("ctx: ", ctx)
-		// fmt.Printf("fields: %v\n", fields)
 		f := make(map[string]any, len(fields)/2)
-		l := logger
 		i := logging.Fields(fields).Iterator()
 		for i.Next() {
 			k, v := i.At()
 			f[k] = v
-			l = l.With(k, v)
-			// fmt.Printf("k %v, v %v\n", k, v)
 		}
-
-		// fmt.Println(lvl, msg)
-		// l.Info("blah")
 
 		switch lvl {
 		case logging.LevelDebug:
-			l.Debug(msg)
+			logger.Debug(msg, f)
 		case logging.LevelInfo:
-			l.Info(msg)
+			logger.Info(msg, f)
 		case logging.LevelWarn:
-			l.Warn(msg)
+			logger.Warn(msg, f)
 		case logging.LevelError:
-			l.Error(msg)
+			logger.Error(msg, f)
 		default:
 			panic(fmt.Sprintf("unknown level %v", lvl))
 		}

--- a/httpmw/recovery/recovery.go
+++ b/httpmw/recovery/recovery.go
@@ -1,20 +1,20 @@
 package recovery
 
 import (
-	"log/slog"
 	"net/http"
 
+	"github.com/Azure/aks-middleware/unifiedlogger"
 	"github.com/gorilla/mux"
 )
 
-type PanicHandlerFunc func(logger slog.Logger, w http.ResponseWriter, r *http.Request, err interface{})
+type PanicHandlerFunc func(logger unifiedlogger.LoggerWrapper, w http.ResponseWriter, r *http.Request, err interface{})
 
-func defaultPanicHandler(logger slog.Logger, w http.ResponseWriter, r *http.Request, err interface{}) {
-	logger.Error("Panic occurred", "error", err)
+func defaultPanicHandler(logger unifiedlogger.LoggerWrapper, w http.ResponseWriter, r *http.Request, err interface{}) {
+	logger.Error("Panic occurred", map[string]interface{}{"error": err})
 	http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 }
 
-func NewPanicHandling(logger *slog.Logger, panicHandler PanicHandlerFunc) mux.MiddlewareFunc {
+func NewPanicHandling(logger *unifiedlogger.LoggerWrapper, panicHandler PanicHandlerFunc) mux.MiddlewareFunc {
 	if panicHandler == nil {
 		panicHandler = defaultPanicHandler
 	}
@@ -29,7 +29,7 @@ func NewPanicHandling(logger *slog.Logger, panicHandler PanicHandlerFunc) mux.Mi
 
 type panicHandlingMiddleware struct {
 	next         http.Handler
-	logger       slog.Logger
+	logger       unifiedlogger.LoggerWrapper
 	panicHandler PanicHandlerFunc
 }
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,21 +1,21 @@
 package policy
 
 import (
-	log "log/slog"
 	"net/http"
 	"time"
 
 	"github.com/Azure/aks-middleware/logging"
+	"github.com/Azure/aks-middleware/unifiedlogger"
 	armPolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
 	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"google.golang.org/grpc/codes"
 )
 
 type LoggingPolicy struct {
-	logger log.Logger
+	logger unifiedlogger.LoggerWrapper
 }
 
-func NewLoggingPolicy(logger log.Logger) *LoggingPolicy {
+func NewLoggingPolicy(logger unifiedlogger.LoggerWrapper) *LoggingPolicy {
 	return &LoggingPolicy{logger: logger}
 }
 
@@ -37,7 +37,7 @@ func (p *LoggingPolicy) Clone() azcorePolicy.Policy {
 	return &LoggingPolicy{logger: p.logger}
 }
 
-func GetDefaultArmClientOptions(logger *log.Logger) *armPolicy.ClientOptions {
+func GetDefaultArmClientOptions(logger *unifiedlogger.LoggerWrapper) *armPolicy.ClientOptions {
 	logOptions := new(azcorePolicy.LogOptions)
 
 	retryOptions := new(azcorePolicy.RetryOptions)

--- a/restlogger/restlogger.go
+++ b/restlogger/restlogger.go
@@ -1,16 +1,16 @@
 package restlogger
 
 import (
-	log "log/slog"
 	"net/http"
 	"time"
 
 	"github.com/Azure/aks-middleware/logging"
+	"github.com/Azure/aks-middleware/unifiedlogger"
 )
 
 type LoggingRoundTripper struct {
 	Proxied http.RoundTripper
-	Logger  *log.Logger
+	Logger  *unifiedlogger.LoggerWrapper
 }
 
 func (lrt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -26,7 +26,7 @@ func (lrt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 	return resp, err
 }
 
-func NewLoggingClient(logger *log.Logger) *http.Client {
+func NewLoggingClient(logger *unifiedlogger.LoggerWrapper) *http.Client {
 	return &http.Client{
 		Transport: &LoggingRoundTripper{
 			Proxied: http.DefaultTransport,


### PR DESCRIPTION
Update logging mechanism to use `UnifiedLogger` instead of `slog`.

* **autologger/autologger.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `InterceptorLogger` function to use `UnifiedLogger`.
  - Update `GetFields` function to use `UnifiedLogger`.

* **ctxlogger/ctxlogger.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `ExtractFunction` type to use `UnifiedLogger`.
  - Update `WithLogger` function to use `UnifiedLogger`.
  - Update `GetLogger` function to use `UnifiedLogger`.
  - Update `UnaryServerInterceptor` function to use `UnifiedLogger`.
  - Update `defaultExtractFunction` function to use `UnifiedLogger`.
  - Update `FilterLogs` function to use `UnifiedLogger`.

* **httpmw/logging/logging.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `NewLogging` function to use `UnifiedLogger`.
  - Update `loggingMiddleware` struct to use `UnifiedLogger`.
  - Update `LogRequestStart` function to use `UnifiedLogger`.
  - Update `LogRequestEnd` function to use `UnifiedLogger`.

* **httpmw/recovery/recovery.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `PanicHandlerFunc` type to use `UnifiedLogger`.
  - Update `defaultPanicHandler` function to use `UnifiedLogger`.
  - Update `NewPanicHandling` function to use `UnifiedLogger`.
  - Update `panicHandlingMiddleware` struct to use `UnifiedLogger`.

* **interceptor/interceptor.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `ClientInterceptorLogOptions` struct to use `UnifiedLogger`.
  - Update `ServerInterceptorLogOptions` struct to use `UnifiedLogger`.
  - Update `GetClientInterceptorLogOptions` function to use `UnifiedLogger`.
  - Update `GetServerInterceptorLogOptions` function to use `UnifiedLogger`.
  - Update `DefaultClientInterceptors` function to use `UnifiedLogger`.
  - Update `DefaultServerInterceptors` function to use `UnifiedLogger`.

* **logging/logging.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `LogRequestParams` struct to use `UnifiedLogger`.
  - Update `LogRequest` function to use `UnifiedLogger`.

* **policy/policy.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `LoggingPolicy` struct to use `UnifiedLogger`.
  - Update `NewLoggingPolicy` function to use `UnifiedLogger`.
  - Update `Do` function to use `UnifiedLogger`.
  - Update `Clone` function to use `UnifiedLogger`.
  - Update `GetDefaultArmClientOptions` function to use `UnifiedLogger`.

* **restlogger/restlogger.go**
  - Replace `slog` with `UnifiedLogger` for logging.
  - Update import statements to use `UnifiedLogger`.
  - Update `LoggingRoundTripper` struct to use `UnifiedLogger`.
  - Update `RoundTrip` function to use `UnifiedLogger`.
  - Update `NewLoggingClient` function to use `UnifiedLogger`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Azure/aks-middleware?shareId=b2d34945-a424-4d43-bf46-27d24da5766f).