### PR TITLE
adding logging attrs to panic logs

### DIFF
--- a/httpmw/logging/logging.go
+++ b/httpmw/logging/logging.go
@@ -65,7 +65,7 @@ func (l *loggingMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	l.LogRequestEnd(ctx, r, "finished call", customWriter.statusCode, latency)
 }
 
-func (l *loggingMiddleware) buildAttributes(ctx context.Context, r *http.Request, extra ...interface{}) []interface{} {
+func BuildAttributes(ctx context.Context, r *http.Request, extra ...interface{}) []interface{} {
 	md, ok := metadata.FromIncomingContext(ctx)
 	attributes := []interface{}{
 		"source", "ApiRequestLog",
@@ -92,11 +92,11 @@ func (l *loggingMiddleware) buildAttributes(ctx context.Context, r *http.Request
 }
 
 func (l *loggingMiddleware) LogRequestStart(ctx context.Context, r *http.Request, msg string) {
-	attributes := l.buildAttributes(ctx, r)
+	attributes := BuildAttributes(ctx, r)
 	l.logger.InfoContext(ctx, msg, attributes...)
 }
 
 func (l *loggingMiddleware) LogRequestEnd(ctx context.Context, r *http.Request, msg string, statusCode int, duration time.Duration) {
-	attributes := l.buildAttributes(ctx, r, "code", statusCode, "time_ms", duration.Milliseconds())
+	attributes := BuildAttributes(ctx, r, "code", statusCode, "time_ms", duration.Milliseconds())
 	l.logger.InfoContext(ctx, msg, attributes...)
 }

--- a/httpmw/recovery/recovery.go
+++ b/httpmw/recovery/recovery.go
@@ -4,13 +4,15 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/Azure/aks-middleware/httpmw/logging"
 	"github.com/gorilla/mux"
 )
 
 type PanicHandlerFunc func(logger slog.Logger, w http.ResponseWriter, r *http.Request, err interface{})
 
 func defaultPanicHandler(logger slog.Logger, w http.ResponseWriter, r *http.Request, err interface{}) {
-	logger.Error("Panic occurred", "error", err)
+	attributes := logging.BuildAttributes(r.Context(), r, "error", err)
+	logger.ErrorContext(r.Context(), "Panic occurred", attributes...)
 	http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 }
 


### PR DESCRIPTION
Using BuildAttributes() helper function to add necessary logging attributes when panics are logged in the default handler