### PR TITLE
Logging out Headers/Metadata

### DIFF
--- a/autologger/autologger.go
+++ b/autologger/autologger.go
@@ -9,9 +9,6 @@ import (
 
 	log "log/slog"
 
-	"github.com/Azure/aks-middleware/common"
-	"github.com/Azure/aks-middleware/requestid"
-
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
@@ -45,16 +42,4 @@ func InterceptorLogger(logger *log.Logger) logging.Logger {
 			panic(fmt.Sprintf("unknown level %v", lvl))
 		}
 	})
-}
-
-// Add request-id & headers to API autologger.
-func GetFields(ctx context.Context) logging.Fields {
-	headers := requestid.GetMetadata(ctx)
-	requestID := headers[common.RequestIDMetadataKey]
-	// Remove the main request ID from headers map since it's logged separately
-	delete(headers, common.RequestIDMetadataKey)
-	return logging.Fields{
-		common.RequestIDLogKey, requestID,
-		"headers", headers,
-	}
 }

--- a/autologger/autologger.go
+++ b/autologger/autologger.go
@@ -9,6 +9,7 @@ import (
 
 	log "log/slog"
 
+	"github.com/Azure/aks-middleware/common"
 	"github.com/Azure/aks-middleware/requestid"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -48,12 +49,12 @@ func InterceptorLogger(logger *log.Logger) logging.Logger {
 
 // Add request-id & headers to API autologger.
 func GetFields(ctx context.Context) logging.Fields {
-	headers := requestid.GetRequestHeaders(ctx)
-	requestID := headers[requestid.RequestIDMetadataKey]
+	headers := requestid.GetMetadata(ctx)
+	requestID := headers[common.RequestIDMetadataKey]
 	// Remove the main request ID from headers map since it's logged separately
-	delete(headers, requestid.RequestIDMetadataKey)
+	delete(headers, common.RequestIDMetadataKey)
 	return logging.Fields{
-		requestid.RequestIDLogKey, requestID,
+		common.RequestIDLogKey, requestID,
 		"headers", headers,
 	}
 }

--- a/autologger/autologger.go
+++ b/autologger/autologger.go
@@ -46,9 +46,14 @@ func InterceptorLogger(logger *log.Logger) logging.Logger {
 	})
 }
 
-// Add request-id to API autologger.
+// Add request-id & headers to API autologger.
 func GetFields(ctx context.Context) logging.Fields {
+	headers := requestid.GetRequestHeaders(ctx)
+	requestID := headers[requestid.RequestIDMetadataKey]
+	// Remove the main request ID from headers map since it's logged separately
+	delete(headers, requestid.RequestIDMetadataKey)
 	return logging.Fields{
-		requestid.RequestIDLogKey, requestid.GetRequestID(ctx),
+		requestid.RequestIDLogKey, requestID,
+		"headers", headers,
 	}
 }

--- a/common/common_suite_test.go
+++ b/common/common_suite_test.go
@@ -1,0 +1,13 @@
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/common/const.go
+++ b/common/const.go
@@ -1,0 +1,15 @@
+package common
+
+const (
+	CorrelationIDKey      = "correlationID"
+	OperationIDKey        = "operationID"
+	ARMClientRequestIDKey = "armClientRequestID"
+
+	// Details can be found here:
+	// https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#client-request-headers
+	RequestCorrelationIDHeader = "x-ms-correlation-request-id"
+	// RequestAcsOperationIDHeader is the http header name ACS RP adds for operation ID (AKS specific)
+	RequestAcsOperationIDHeader = "x-ms-acs-operation-id"
+	// RequestARMClientRequestIDHeader  Caller-specified value identifying the request, in the form of a GUID
+	RequestARMClientRequestIDHeader = "x-ms-client-request-id"
+)

--- a/common/const.go
+++ b/common/const.go
@@ -4,6 +4,7 @@ const (
 	CorrelationIDKey      = "correlationID"
 	OperationIDKey        = "operationID"
 	ARMClientRequestIDKey = "armClientRequestID"
+	RequestIDLogKey       = "request-id"
 
 	// Details can be found here:
 	// https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#client-request-headers
@@ -12,4 +13,7 @@ const (
 	RequestAcsOperationIDHeader = "x-ms-acs-operation-id"
 	// RequestARMClientRequestIDHeader  Caller-specified value identifying the request, in the form of a GUID
 	RequestARMClientRequestIDHeader = "x-ms-client-request-id"
+	// RequestIDMetadataKey is the key in the gRPC
+	// metadata.
+	RequestIDMetadataKey = "x-request-id"
 )

--- a/common/const.go
+++ b/common/const.go
@@ -15,5 +15,5 @@ const (
 	RequestARMClientRequestIDHeader = "x-ms-client-request-id"
 	// RequestIDMetadataKey is the key in the gRPC
 	// metadata.
-	RequestIDMetadataKey = "x-request-id"
+	RequestIDMetadataHeader = "x-request-id"
 )

--- a/common/const.go
+++ b/common/const.go
@@ -1,9 +1,9 @@
 package common
 
 const (
-	CorrelationIDKey      = "correlationID"
-	OperationIDKey        = "operationID"
-	ARMClientRequestIDKey = "armClientRequestID"
+	CorrelationIDKey      = "correlationid"
+	OperationIDKey        = "operationid"
+	ARMClientRequestIDKey = "armclientrequestid"
 	RequestIDLogKey       = "request-id"
 
 	// Details can be found here:

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"google.golang.org/grpc/metadata"
+)
+
+func GetFields(ctx context.Context) logging.Fields {
+	headers := GetMetadata(ctx)
+	requestID := headers[RequestIDMetadataKey]
+	// Remove the main request ID from headers map since it's logged separately
+	delete(headers, RequestIDMetadataKey)
+	return logging.Fields{
+		RequestIDLogKey, requestID,
+		"headers", headers,
+	}
+}
+
+func GetMetadata(ctx context.Context) map[string]string {
+	headersFromMD := make(map[string]string)
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return headersFromMD
+	}
+	for _, key := range []string{
+		RequestIDMetadataKey,
+		CorrelationIDKey,
+		OperationIDKey,
+		ARMClientRequestIDKey,
+	} {
+		if vals := md.Get(key); len(vals) > 0 {
+			headersFromMD[key] = vals[0]
+		}
+	}
+	return headersFromMD
+}

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -7,25 +7,22 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// GetFields returns a logging.Fields object with the request ID and headers
 func GetFields(ctx context.Context) logging.Fields {
-	headers := GetMetadata(ctx)
-	requestID := headers[RequestIDMetadataKey]
-	// Remove the main request ID from headers map since it's logged separately
-	delete(headers, RequestIDMetadataKey)
+	headers := getMetadata(ctx)
 	return logging.Fields{
-		RequestIDLogKey, requestID,
 		"headers", headers,
 	}
 }
 
-func GetMetadata(ctx context.Context) map[string]string {
+func getMetadata(ctx context.Context) map[string]string {
 	headersFromMD := make(map[string]string)
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return headersFromMD
 	}
 	for _, key := range []string{
-		RequestIDMetadataKey,
+		RequestIDMetadataHeader,
 		CorrelationIDKey,
 		OperationIDKey,
 		ARMClientRequestIDKey,

--- a/ctxlogger/ctxlogger.go
+++ b/ctxlogger/ctxlogger.go
@@ -5,7 +5,7 @@ import (
 
 	"encoding/json"
 
-	"github.com/Azure/aks-middleware/requestid"
+	"github.com/Azure/aks-middleware/autologger"
 
 	log "log/slog"
 
@@ -75,7 +75,7 @@ const (
 func defaultExtractFunction(ctx context.Context, req any, info *grpc.UnaryServerInfo, logger *log.Logger) *log.Logger {
 	l := logger
 	l = l.With(methodLogKey, info.FullMethod)
-	l = l.With(requestid.RequestIDLogKey, requestid.GetRequestHeaders(ctx))
+	l = l.With(autologger.GetFields(ctx)...)
 	return l
 }
 

--- a/ctxlogger/ctxlogger.go
+++ b/ctxlogger/ctxlogger.go
@@ -5,11 +5,10 @@ import (
 
 	"encoding/json"
 
-	"github.com/Azure/aks-middleware/autologger"
-
 	log "log/slog"
 
 	loggable "buf.build/gen/go/service-hub/loggable/protocolbuffers/go/proto"
+	"github.com/Azure/aks-middleware/common"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -75,7 +74,7 @@ const (
 func defaultExtractFunction(ctx context.Context, req any, info *grpc.UnaryServerInfo, logger *log.Logger) *log.Logger {
 	l := logger
 	l = l.With(methodLogKey, info.FullMethod)
-	l = l.With(autologger.GetFields(ctx)...)
+	l = l.With(common.GetFields(ctx)...)
 	return l
 }
 

--- a/ctxlogger/ctxlogger.go
+++ b/ctxlogger/ctxlogger.go
@@ -75,7 +75,7 @@ const (
 func defaultExtractFunction(ctx context.Context, req any, info *grpc.UnaryServerInfo, logger *log.Logger) *log.Logger {
 	l := logger
 	l = l.With(methodLogKey, info.FullMethod)
-	l = l.With(requestid.RequestIDLogKey, requestid.GetRequestID(ctx))
+	l = l.With(requestid.RequestIDLogKey, requestid.GetRequestHeaders(ctx))
 	return l
 }
 

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Azure/aks-middleware/autologger"
+	"github.com/Azure/aks-middleware/common"
 	"github.com/Azure/aks-middleware/ctxlogger"
 	"github.com/Azure/aks-middleware/mdforward"
 	"github.com/Azure/aks-middleware/requestid"
@@ -79,7 +80,7 @@ func DefaultClientInterceptors(options ClientInterceptorLogOptions) []grpc.Unary
 			autologger.InterceptorLogger(apiRequestLogger),
 			logging.WithLogOnEvents(logging.FinishCall),
 			logging.WithLevels(logging.DefaultServerCodeToLevel),
-			logging.WithFieldsFromContext(autologger.GetFields),
+			logging.WithFieldsFromContext(common.GetFields),
 		),
 	}
 }
@@ -140,7 +141,7 @@ func DefaultServerInterceptors(options ServerInterceptorLogOptions) []grpc.Unary
 		logging.UnaryServerInterceptor(
 			autologger.InterceptorLogger(apiRequestLogger),
 			logging.WithLogOnEvents(logging.FinishCall),
-			logging.WithFieldsFromContext(autologger.GetFields),
+			logging.WithFieldsFromContext(common.GetFields),
 		),
 		recovery.UnaryServerInterceptor(GetRecoveryOpts()...),
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -149,8 +149,15 @@ func extractHeaders(header http.Header) map[string]string {
 		common.RequestARMClientRequestIDHeader,
 	}
 
+	// Convert header keys to lowercase
+	lowerHeader := make(http.Header)
+	for key, values := range header {
+		lowerHeader[strings.ToLower(key)] = values
+	}
+
 	for _, key := range headerKeys {
-		if values, ok := header[key]; ok && len(values) > 0 {
+		lowerKey := strings.ToLower(key)
+		if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
 			headers[key] = values[0]
 		}
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/aks-middleware/common"
 	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
@@ -114,6 +115,9 @@ func LogRequest(params LogRequestParams) {
 
 	methodInfo := getMethodInfo(method, reqURL)
 	latency := time.Since(params.StartTime).Milliseconds()
+
+	headers := extractHeaders(params.Response.Header)
+
 	logEntry := params.Logger.With(
 		"source", "ApiRequestLog",
 		"protocol", "REST",
@@ -123,6 +127,7 @@ func LogRequest(params LogRequestParams) {
 		"method", methodInfo,
 		"service", service,
 		"url", reqURL,
+		"headers", headers,
 	)
 
 	if params.Error != nil || params.Response == nil {
@@ -132,4 +137,23 @@ func LogRequest(params LogRequestParams) {
 	} else {
 		logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
 	}
+}
+
+func extractHeaders(header http.Header) map[string]string {
+	headers := make(map[string]string)
+
+	// List of headers to extract
+	headerKeys := []string{
+		common.RequestCorrelationIDHeader,
+		common.RequestAcsOperationIDHeader,
+		common.RequestARMClientRequestIDHeader,
+	}
+
+	for _, key := range headerKeys {
+		if values, ok := header[key]; ok && len(values) > 0 {
+			headers[key] = values[0]
+		}
+	}
+
+	return headers
 }

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"io"
 
+	"github.com/Azure/aks-middleware/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -50,14 +51,21 @@ func shortID() string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 
-func GetRequestID(ctx context.Context) string {
-	requestID := ""
+func GetRequestHeaders(ctx context.Context) map[string]string {
+	headers := make(map[string]string)
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return requestID
+		return headers
 	}
-	if vals := md.Get(RequestIDMetadataKey); len(vals) > 0 {
-		return vals[0]
+	for _, key := range []string{
+		RequestIDMetadataKey,
+		common.CorrelationIDKey,
+		common.OperationIDKey,
+		common.ARMClientRequestIDKey,
+	} {
+		if vals := md.Get(key); len(vals) > 0 {
+			headers[key] = vals[0]
+		}
 	}
-	return requestID
+	return headers
 }

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -43,22 +43,3 @@ func shortID() string {
 	io.ReadFull(rand.Reader, b)
 	return base64.RawURLEncoding.EncodeToString(b)
 }
-
-func GetMetadata(ctx context.Context) map[string]string {
-	headersFromMD := make(map[string]string)
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return headersFromMD
-	}
-	for _, key := range []string{
-		common.RequestIDMetadataKey,
-		common.CorrelationIDKey,
-		common.OperationIDKey,
-		common.ARMClientRequestIDKey,
-	} {
-		if vals := md.Get(key); len(vals) > 0 {
-			headersFromMD[key] = vals[0]
-		}
-	}
-	return headersFromMD
-}

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -14,13 +14,6 @@ import (
 
 // Derived from https://github.com/goadesign/goa/blob/v3/grpc/middleware/requestid.go#L31
 
-const (
-	// RequestIDMetadataKey is the key in the gRPC
-	// metadata.
-	RequestIDMetadataKey = "x-request-id"
-	RequestIDLogKey      = "request-id"
-)
-
 // UnaryServerInterceptor returns a server interceptor
 // that add a request ID to the incoming metadata if there is none.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
@@ -37,10 +30,10 @@ func generateRequestID(ctx context.Context) context.Context {
 	if !ok {
 		md = metadata.MD{}
 	}
-	if vals := md.Get(RequestIDMetadataKey); len(vals) > 0 {
+	if vals := md.Get(common.RequestIDMetadataKey); len(vals) > 0 {
 		return ctx
 	}
-	md.Set(RequestIDMetadataKey, shortID())
+	md.Set(common.RequestIDMetadataKey, shortID())
 	return metadata.NewIncomingContext(ctx, md)
 
 }
@@ -51,21 +44,21 @@ func shortID() string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 
-func GetRequestHeaders(ctx context.Context) map[string]string {
-	headers := make(map[string]string)
+func GetMetadata(ctx context.Context) map[string]string {
+	headersFromMD := make(map[string]string)
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return headers
+		return headersFromMD
 	}
 	for _, key := range []string{
-		RequestIDMetadataKey,
+		common.RequestIDMetadataKey,
 		common.CorrelationIDKey,
 		common.OperationIDKey,
 		common.ARMClientRequestIDKey,
 	} {
 		if vals := md.Get(key); len(vals) > 0 {
-			headers[key] = vals[0]
+			headersFromMD[key] = vals[0]
 		}
 	}
-	return headers
+	return headersFromMD
 }

--- a/requestid/requestid.go
+++ b/requestid/requestid.go
@@ -30,10 +30,10 @@ func generateRequestID(ctx context.Context) context.Context {
 	if !ok {
 		md = metadata.MD{}
 	}
-	if vals := md.Get(common.RequestIDMetadataKey); len(vals) > 0 {
+	if vals := md.Get(common.RequestIDMetadataHeader); len(vals) > 0 {
 		return ctx
 	}
-	md.Set(common.RequestIDMetadataKey, shortID())
+	md.Set(common.RequestIDMetadataHeader, shortID())
 	return metadata.NewIncomingContext(ctx, md)
 
 }


### PR DESCRIPTION
This PR ensures that headers that have been converted to metadata are logged out by the autologger and the restlogger.