### PR TITLE
Using Resource Identifier for HTTP Request Logging

### DIFF
--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -56,6 +56,7 @@ func getMethodInfo(method string, rawURL string) string {
     id, err := arm.ParseResourceID(validURL)
     if err != nil {
         // Retry by appending a false resource name ("dummy")
+		// To be a valid resource ID, the URL must end with the resource name.
         fakeURL := validURL
         if !strings.HasSuffix(validURL, "/dummy") {
             fakeURL = validURL + "/dummy"

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,169 +1,186 @@
 package logging
 
 import (
-	"log/slog"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+    "log/slog"
+    "net/http"
+    "net/url"
+    "strings"
+    "time"
 
-	"github.com/Azure/aks-middleware/http/common"
-	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+    "github.com/Azure/aks-middleware/http/common"
+    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 )
 
-var resourceTypes = map[string]bool{
-	"resourcegroups":        true,
-	"storageaccounts":       true,
-	"operationresults":      true,
-	"asyncoperations":       true,
-	"checknameavailability": true,
-}
-
 type LogRequestParams struct {
-	Logger    *slog.Logger
-	StartTime time.Time
-	Request   interface{}
-	Response  *http.Response
-	Error     error
+    Logger    *slog.Logger
+    StartTime time.Time
+    Request   interface{}
+    Response  *http.Response
+    Error     error
 }
 
-// Shared logging function for REST API interactions
+func trimToSubscription(rawURL string) string {
+    // Find the index of "/subscriptions"
+    if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
+        return rawURL[idx:]
+    }
+    return rawURL
+}
+
+func sanitizeResourceType(rt string, rawURL string) string {
+	// Keep only the substring after the last slash.
+    if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
+        rt = rt[idx+1:]
+    }
+    // Remove any query parameters, e.g. "api-version=..."
+    if idx := strings.Index(rt, "api-version"); idx != -1 {
+        rt = rt[:idx]
+    }
+    
+	// Remove any trailing '?' and convert to lowercase.
+	rt = strings.ToLower(strings.TrimSuffix(rt, "?"))
+    
+	// If the resource type is empty, return the raw URL.
+	if rt == "" {
+		return rawURL
+	}
+    return rt
+}
+
 func getMethodInfo(method string, rawURL string) string {
-	urlParts := strings.Split(rawURL, "?api-version")
-	// malformed url
-	// check for v1 to ensure we aren't classifying restlogger as malformed
-	if len(urlParts) < 2 && !strings.Contains(urlParts[0], "v1") {
-		return method + " " + rawURL
-	}
-	parts := strings.Split(urlParts[0], "/")
-	resource := urlParts[0]
-	counter := 0
-	// Start from the end of the split path and move backward
-	// to get nested resource type
-	for counter = len(parts) - 1; counter >= 0; counter-- {
-		currToken := strings.ToLower(parts[counter])
-		if strings.ContainsAny(currToken, "?/") {
-			index := strings.IndexAny(currToken, "?/")
-			currToken = currToken[:index]
-		}
-		if resourceTypes[currToken] {
-			resource = currToken
-			break
-		}
-	}
+    // Trim the URL to ensure it starts with "/subscriptions"
+    validURL := trimToSubscription(rawURL)
 
-	if method == "GET" {
-		// resource name is specified, so it is a READ op
-		if counter == len(parts)-1 {
-			resource = resource + " - LIST"
-		} else {
-			resource = resource + " - READ"
-		}
-	}
+    // First, try to parse validURL as a full resource ID.
+    id, err := arm.ParseResourceID(validURL)
+    if err != nil {
+        // Retry by appending a false resource name ("dummy")
+        fakeURL := validURL
+        if !strings.HasSuffix(validURL, "/dummy") {
+            fakeURL = validURL + "/dummy"
+        }
+        id, err = arm.ParseResourceID(fakeURL)
+        if err != nil {
+            // Fallback: if parsing still fails, use the full URL.
+            return method + " " + rawURL
+        }
+        // We know a fake resource name was added.
+        if method == "GET" {
+            // For GET requests with a fake name, we assume it's a list operation.
+            return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
+        }
+        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+    }
 
-	// REST VERB + Resource Type
-	methodInfo := method + " " + resource
-
-	return methodInfo
+    // If parsing was successful on the first try.
+    if method == "GET" {
+        op := " - READ"
+        if strings.TrimSpace(id.Name) == "" {
+            op = " - LIST"
+        }
+        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
+    }
+    return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
 }
 
 func trimURL(parsedURL url.URL) string {
-	// Extract the `api-version` parameter
-	apiVersion := parsedURL.Query().Get("api-version")
+    // Extract the `api-version` parameter
+    apiVersion := parsedURL.Query().Get("api-version")
 
-	// Reconstruct the URL with only the `api-version` parameter
-	baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
-	if apiVersion != "" {
-		return baseURL + "?api-version=" + apiVersion
-	}
-	return baseURL
+    // Reconstruct the URL with only the `api-version` parameter
+    baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
+    if apiVersion != "" {
+        return baseURL + "?api-version=" + apiVersion
+    }
+    return baseURL
 }
 
 func LogRequest(params LogRequestParams) {
-	var method, service, reqURL string
-	switch req := params.Request.(type) {
-	case *http.Request:
-		method = req.Method
-		service = req.Host
-		reqURL = req.URL.String()
+    var method, service, reqURL string
+    switch req := params.Request.(type) {
+    case *http.Request:
+        method = req.Method
+        service = req.Host
+        reqURL = req.URL.String()
 
-	case *azcorePolicy.Request:
-		method = req.Raw().Method
-		service = req.Raw().Host
-		reqURL = req.Raw().URL.String()
-	default:
-		return // Unknown request type, do nothing
-	}
+    case *azcorePolicy.Request:
+        method = req.Raw().Method
+        service = req.Raw().Host
+        reqURL = req.Raw().URL.String()
+    default:
+        return // Unknown request type, do nothing
+    }
 
-	parsedURL, parseErr := url.Parse(reqURL)
-	if parseErr != nil {
-		params.Logger.With(
-			"source", "ApiRequestLog",
-			"protocol", "REST",
-			"method_type", "unary",
-			"code", "na",
-			"component", "client",
-			"time_ms", "na",
-			"method", method,
-			"service", service,
-			"url", reqURL,
-			"error", parseErr.Error(),
-		).Error("error parsing request URL")
-	} else {
-		reqURL = trimURL(*parsedURL)
-	}
+    parsedURL, parseErr := url.Parse(reqURL)
+    if parseErr != nil {
+        params.Logger.With(
+            "source", "ApiRequestLog",
+            "protocol", "REST",
+            "method_type", "unary",
+            "code", "na",
+            "component", "client",
+            "time_ms", "na",
+            "method", method,
+            "service", service,
+            "url", reqURL,
+            "error", parseErr.Error(),
+        ).Error("error parsing request URL")
+    } else {
+        reqURL = trimURL(*parsedURL)
+    }
 
-	methodInfo := getMethodInfo(method, reqURL)
-	latency := time.Since(params.StartTime).Milliseconds()
+    methodInfo := getMethodInfo(method, reqURL)
+    latency := time.Since(params.StartTime).Milliseconds()
 
-	var headers map[string]string
-	if params.Response != nil {
-		headers = extractHeaders(params.Response.Header)
-	}
+    var headers map[string]string
+    if params.Response != nil {
+        headers = extractHeaders(params.Response.Header)
+    }
 
-	logEntry := params.Logger.With(
-		"source", "ApiRequestLog",
-		"protocol", "REST",
-		"method_type", "unary",
-		"component", "client",
-		"time_ms", latency,
-		"method", methodInfo,
-		"service", service,
-		"url", reqURL,
-		"headers", headers,
-	)
+    logEntry := params.Logger.With(
+        "source", "ApiRequestLog",
+        "protocol", "REST",
+        "method_type", "unary",
+        "component", "client",
+        "time_ms", latency,
+        "method", methodInfo,
+        "service", service,
+        "url", reqURL,
+        "headers", headers,
+    )
 
-	if params.Error != nil || params.Response == nil {
-		logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
-	} else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
-		logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
-	} else {
-		logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
-	}
+    if params.Error != nil || params.Response == nil {
+        logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
+    } else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
+        logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
+    } else {
+        logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
+    }
 }
 
 func extractHeaders(header http.Header) map[string]string {
-	headers := make(map[string]string)
+    headers := make(map[string]string)
 
-	// List of headers to extract
-	headerKeys := []string{
-		common.RequestCorrelationIDHeader,
-		common.RequestAcsOperationIDHeader,
-		common.RequestARMClientRequestIDHeader,
-	}
+    // List of headers to extract
+    headerKeys := []string{
+        common.RequestCorrelationIDHeader,
+        common.RequestAcsOperationIDHeader,
+        common.RequestARMClientRequestIDHeader,
+    }
 
-	// Convert header keys to lowercase
-	lowerHeader := make(http.Header)
-	for key, values := range header {
-		lowerHeader[strings.ToLower(key)] = values
-	}
+    // Convert header keys to lowercase
+    lowerHeader := make(http.Header)
+    for key, values := range header {
+        lowerHeader[strings.ToLower(key)] = values
+    }
 
-	for _, key := range headerKeys {
-		lowerKey := strings.ToLower(key)
-		if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
-			headers[key] = values[0]
-		}
-	}
+    for _, key := range headerKeys {
+        lowerKey := strings.ToLower(key)
+        if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
+            headers[key] = values[0]
+        }
+    }
 
-	return headers
+    return headers
 }

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -29,22 +29,21 @@ func trimToSubscription(rawURL string) string {
 }
 
 func sanitizeResourceType(rt string, rawURL string) string {
-	// Keep only the substring after the last slash.
+    // Keep only the substring after the last slash.
     if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
         rt = rt[idx+1:]
     }
-    // Remove any query parameters, e.g. "api-version=..."
-    if idx := strings.Index(rt, "api-version"); idx != -1 {
+    // Remove everything after the first '?'.
+    if idx := strings.Index(rt, "?"); idx != -1 {
         rt = rt[:idx]
     }
     
-	// Remove any trailing '?' and convert to lowercase.
-	rt = strings.ToLower(strings.TrimSuffix(rt, "?"))
+    rt = strings.ToLower(rt)
     
-	// If the resource type is empty, return the raw URL.
-	if rt == "" {
-		return rawURL
-	}
+    // If the remaining resource type is empty or still contains api-version, its a malformed URL
+    if rt == "" ||  strings.Contains(rt, "api-version") {
+        return rawURL
+    }
     return rt
 }
 

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -37,13 +37,8 @@ func sanitizeResourceType(rt string, rawURL string) string {
     if idx := strings.Index(rt, "?"); idx != -1 {
         rt = rt[:idx]
     }
-    
     rt = strings.ToLower(rt)
     
-    // If the remaining resource type is empty or still contains api-version, its a malformed URL
-    if rt == "" ||  strings.Contains(rt, "api-version") {
-        return rawURL
-    }
     return rt
 }
 

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -101,23 +101,6 @@ var _ = Describe("LogRequest", func() {
 		})
 	})
 
-	Context("when URL is malformed", func() {
-		It("logs the correct method with the entire URL", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name/api-version=version")
-			Expect(err).To(BeNil())
-
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "GET https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name/api-version=version"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
 	Context("when using a custom resource type", func() {
 		It("logs the correct method info", func() {
 			parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -118,8 +118,8 @@ var _ = Describe("LogRequest", func() {
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})
 	})
-	Context("when the resource type is not found", func() {
-		It("logs the correct method with the entire URL", func() {
+	Context("when using a custom resource type", func() {
+		It("logs the correct method info", func() {
 			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/customResourceGroup/resource_name/providers/Microsoft.Storage/customResource/resource_name?api-version=version")
 			Expect(err).To(BeNil())
 
@@ -130,7 +130,7 @@ var _ = Describe("LogRequest", func() {
 				Response:  &http.Response{StatusCode: 200},
 				Error:     nil,
 			}
-			expected := "GET https://management.azure.com/subscriptions/sub_id/customResourceGroup/resource_name/providers/Microsoft.Storage/customResource/resource_name - READ"
+			expected := "GET customresource - READ"
 			logging.LogRequest(params)
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})
@@ -152,9 +152,9 @@ var _ = Describe("LogRequest", func() {
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})
 	})
-	Context("when there are zero query parameters", func() {
-		It("logs the correct method with the entire URL", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts")
+    Context ("when making a request using Node Provisioner Client", func() {
+		It("logs the correct method info", func() {
+			parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
 			Expect(err).To(BeNil())
 
 			params := logging.LogRequestParams{
@@ -164,7 +164,7 @@ var _ = Describe("LogRequest", func() {
 				Response:  &http.Response{StatusCode: 200},
 				Error:     nil,
 			}
-			expected := "GET https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts"
+			expected := "GET nodebootstrapping - LIST"
 			logging.LogRequest(params)
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -120,7 +120,7 @@ var _ = Describe("LogRequest", func() {
 	})
 	Context("when using a custom resource type", func() {
 		It("logs the correct method info", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/customResourceGroup/resource_name/providers/Microsoft.Storage/customResource/resource_name?api-version=version")
+			parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
 			Expect(err).To(BeNil())
 
 			params := logging.LogRequestParams{
@@ -130,7 +130,7 @@ var _ = Describe("LogRequest", func() {
 				Response:  &http.Response{StatusCode: 200},
 				Error:     nil,
 			}
-			expected := "GET customresource - READ"
+			expected := "GET nodebootstrapping - LIST"
 			logging.LogRequest(params)
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})
@@ -148,23 +148,6 @@ var _ = Describe("LogRequest", func() {
 				Error:     nil,
 			}
 			expected := "GET storageaccounts - LIST"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
-    Context ("when making a request using Node Provisioner Client", func() {
-		It("logs the correct method info", func() {
-			parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
-			Expect(err).To(BeNil())
-
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "GET nodebootstrapping - LIST"
 			logging.LogRequest(params)
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})


### PR DESCRIPTION
Using the resource identifier for logging out method info as part of the logs our middleware generates. Moving away from hardcoded "supported" resource types. 

Also added some custom logic on top of resource identifier since it's not perfect when it comes to parsing out the resource type for every use case. 