### PR TITLE
Middleware Logging Updates

### DIFF
--- a/grpc/common/autologger/autologger.go
+++ b/grpc/common/autologger/autologger.go
@@ -13,15 +13,36 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
+// HeadersFunc extracts headers from the context to be added to the logger.
+// It should return a map[string]string containing header key-value pairs.
+type HeadersFunc func(ctx context.Context) map[string]string
+
+// InterceptorLogger creates a logging.Logger that automatically extracts Azure headers from the gRPC context.
+// This is the default implementation that uses common.GetFields to extract standard Azure headers
+// like correlation-id, operation-id, request-id, and arm-client-request-id from gRPC metadata.
 func InterceptorLogger(logger *log.Logger) logging.Logger {
+	return InterceptorLoggerWithHeadersFunc(logger, nil)
+}
+
+// InterceptorLoggerWithHeadersFunc creates a logging.Logger with custom header extraction logic.
+// This provides flexibility to customize which headers are extracted from the context.
+// Pass nil as headersFunc to use the default common.GetFields header extraction.
+func InterceptorLoggerWithHeadersFunc(logger *log.Logger, headersFunc HeadersFunc) logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		// fmt.Println("ctx: ", ctx)
-		// fmt.Printf("fields: %v\n", fields)
 		f := make(map[string]any, len(fields)/2)
 		l := logger
 
-		// add default header fields such as operationId, correlationId, etc
-		l = l.With(common.GetFields(ctx)...)
+		// Add headers using custom function or default common.GetFields
+		// when using custom function, only allow caller to update headers column
+		if headersFunc != nil {
+			headers := headersFunc(ctx)
+			if len(headers) > 0 {
+				l = l.With("headers", headers)
+			}
+		} else {
+			// Use default common.GetFields
+			l = l.With(common.GetFields(ctx)...)
+		}
 
 		// Process the fields from the interceptor
 		i := logging.Fields(fields).Iterator()

--- a/grpc/common/autologger/autologger.go
+++ b/grpc/common/autologger/autologger.go
@@ -9,7 +9,7 @@ import (
 
 	log "log/slog"
 
-	opreq "github.com/Azure/aks-middleware/http/server/operationrequest"
+	"github.com/Azure/aks-middleware/grpc/common"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 )
 
@@ -20,20 +20,8 @@ func InterceptorLogger(logger *log.Logger) logging.Logger {
 		f := make(map[string]any, len(fields)/2)
 		l := logger
 
-		// Extract operation request from context if available
-		if op := opreq.OperationRequestFromContext(ctx); op != nil {
-			// Only add the IDs to the headers field, not as top-level attributes
-			headers := make(map[string]string)
-			if op.CorrelationID != "" {
-				headers["correlation_id"] = op.CorrelationID
-			}
-			if op.OperationID != "" {
-				headers["operation_id"] = op.OperationID
-			}
-			if len(headers) > 0 {
-				l = l.With("headers", headers)
-			}
-		}
+		// add default header fields such as operationId, correlationId, etc
+		l = l.With(common.GetFields(ctx)...)
 
 		// Process the fields from the interceptor
 		i := logging.Fields(fields).Iterator()

--- a/grpc/common/autologger/autologger_test.go
+++ b/grpc/common/autologger/autologger_test.go
@@ -82,4 +82,64 @@ var _ = Describe("Autologger Tests", func() {
 		Expect(ok).To(BeTrue())
 		Expect(headers).To(BeEmpty())
 	})
+
+	It("should use custom header extraction function when provided", func() {
+		// Create incoming metadata
+		md := metadata.Pairs(
+			"x-tenant-id", "tenant-12345",
+			"x-user-id", "user-67890",
+			"x-session-id", "session-abcdef",
+			"x-api-version", "v2.1",
+			httpcommon.CorrelationIDKey, "test-correlation-id",
+		)
+
+		ctx = metadata.NewIncomingContext(ctx, md)
+
+		// Define a custom headers function that extracts different headers
+		customHeadersFunc := func(ctx context.Context) map[string]string {
+			headers := make(map[string]string)
+			if md, ok := metadata.FromIncomingContext(ctx); ok {
+				// Extract only tenant-id, user-id, and api-version
+				if vals := md.Get("x-tenant-id"); len(vals) > 0 {
+					headers["tenant_id"] = vals[0]
+				}
+				if vals := md.Get("x-user-id"); len(vals) > 0 {
+					headers["user_id"] = vals[0]
+				}
+				if vals := md.Get("x-api-version"); len(vals) > 0 {
+					headers["api_version"] = vals[0]
+				}
+			}
+			return headers
+		}
+
+		interceptorLogger := autologger.InterceptorLoggerWithHeadersFunc(logger, customHeadersFunc)
+		interceptorLogger.Log(ctx, logging.LevelInfo, "test message", "key1", "value1")
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buffer.Bytes(), &logEntry)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the headers field contains only the custom extracted headers
+		Expect(logEntry).To(HaveKey("headers"))
+		headers, ok := logEntry["headers"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+
+		// Should contain the custom extracted headers
+		Expect(headers).To(HaveKey("tenant_id"))
+		Expect(headers["tenant_id"]).To(Equal("tenant-12345"))
+		Expect(headers).To(HaveKey("user_id"))
+		Expect(headers["user_id"]).To(Equal("user-67890"))
+		Expect(headers).To(HaveKey("api_version"))
+		Expect(headers["api_version"]).To(Equal("v2.1"))
+
+		// Should NOT contain the headers that weren't extracted by custom function
+		Expect(headers).NotTo(HaveKey("x-session-id"))
+		Expect(headers).NotTo(HaveKey(httpcommon.CorrelationIDKey))
+
+		// Verify basic logging fields are present
+		Expect(logEntry).To(HaveKeyWithValue("key1", "value1"))
+		Expect(logEntry).To(HaveKeyWithValue("msg", "test message"))
+		Expect(logEntry).To(HaveKeyWithValue("level", "INFO"))
+	})
 })

--- a/grpc/common/autologger/autologger_test.go
+++ b/grpc/common/autologger/autologger_test.go
@@ -65,16 +65,7 @@ var _ = Describe("Autologger Tests", func() {
 
 	})
 
-	It("should handle empty correlation and operation IDs correctly", func() {
-		// Create an OperationRequest with empty correlation and operation IDs
-		opRequest := &opreq.BaseOperationRequest{
-			CorrelationID: "",
-			OperationID:   "",
-			Extras:        make(map[string]interface{}),
-		}
-
-		ctx = opreq.OperationRequestWithContext(ctx, opRequest)
-
+	It("should handle nonexistent operation request struct correctly", func() {
 		interceptorLogger := autologger.InterceptorLogger(logger)
 
 		interceptorLogger.Log(ctx, logging.LevelInfo, "test message", "key1", "value1")
@@ -87,5 +78,8 @@ var _ = Describe("Autologger Tests", func() {
 		Expect(logEntry).NotTo(HaveKey("correlation_id"))
 		Expect(logEntry).NotTo(HaveKey("operation_id"))
 		Expect(logEntry).NotTo(HaveKey("headers"))
+		Expect(logEntry).To(HaveKeyWithValue("key1", "value1"))
+		Expect(logEntry).To(HaveKeyWithValue("msg", "test message"))
+		Expect(logEntry).To(HaveKeyWithValue("level", "INFO"))
 	})
 })

--- a/grpc/common/autologger/autologger_test.go
+++ b/grpc/common/autologger/autologger_test.go
@@ -1,0 +1,91 @@
+package autologger_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	log "log/slog"
+
+	"github.com/Azure/aks-middleware/grpc/common/autologger"
+	opreq "github.com/Azure/aks-middleware/http/server/operationrequest"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Autologger Tests", func() {
+	var (
+		buffer  *bytes.Buffer
+		logger  *log.Logger
+		handler *log.JSONHandler
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		handler = log.NewJSONHandler(buffer, nil)
+		logger = log.New(handler)
+		ctx = context.Background()
+	})
+
+	It("should log correlation and operation IDs when OperationRequest is in the context", func() {
+		// Create an OperationRequest with correlation and operation IDs
+		opRequest := &opreq.BaseOperationRequest{
+			CorrelationID: "test-correlation-id",
+			OperationID:   "test-operation-id",
+			Extras:        make(map[string]interface{}),
+		}
+
+		// Add the OperationRequest to the context
+		ctx = opreq.OperationRequestWithContext(ctx, opRequest)
+
+		// Setup the logger
+		interceptorLogger := autologger.InterceptorLogger(logger)
+
+		interceptorLogger.Log(ctx, logging.LevelInfo, "test message", "key1", "value1")
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buffer.Bytes(), &logEntry)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the headers field contains both IDs
+		Expect(logEntry).To(HaveKey("headers"))
+		headers, ok := logEntry["headers"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(headers).To(HaveKey("correlation_id"))
+		Expect(headers["correlation_id"]).To(Equal("test-correlation-id"))
+		Expect(headers).To(HaveKey("operation_id"))
+		Expect(headers["operation_id"]).To(Equal("test-operation-id"))
+
+		// Verify that correlation_id and operation_id are NOT present as top-level attributes
+		// They should only be in the headers field
+		Expect(logEntry).NotTo(HaveKey("correlation_id"))
+		Expect(logEntry).NotTo(HaveKey("operation_id"))
+
+	})
+
+	It("should handle empty correlation and operation IDs correctly", func() {
+		// Create an OperationRequest with empty correlation and operation IDs
+		opRequest := &opreq.BaseOperationRequest{
+			CorrelationID: "",
+			OperationID:   "",
+			Extras:        make(map[string]interface{}),
+		}
+
+		ctx = opreq.OperationRequestWithContext(ctx, opRequest)
+
+		interceptorLogger := autologger.InterceptorLogger(logger)
+
+		interceptorLogger.Log(ctx, logging.LevelInfo, "test message", "key1", "value1")
+
+		var logEntry map[string]interface{}
+		err := json.Unmarshal(buffer.Bytes(), &logEntry)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the correlation and operation IDs are not in the log
+		Expect(logEntry).NotTo(HaveKey("correlation_id"))
+		Expect(logEntry).NotTo(HaveKey("operation_id"))
+		Expect(logEntry).NotTo(HaveKey("headers"))
+	})
+})

--- a/grpc/interceptor/interceptor.go
+++ b/grpc/interceptor/interceptor.go
@@ -82,7 +82,6 @@ func DefaultClientInterceptors(options ClientInterceptorLogOptions) []grpc.Unary
 			autologger.InterceptorLogger(apiRequestLogger),
 			logging.WithLogOnEvents(logging.FinishCall),
 			logging.WithLevels(logging.DefaultServerCodeToLevel),
-			logging.WithFieldsFromContext(common.GetFields),
 		),
 	}
 }

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,247 +1,212 @@
 package logging
 
 import (
-    "bytes"
-    "log/slog"
-    "net/http"
-    "net/url"
-    "strings"
-    "time"
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-    "github.com/Azure/aks-middleware/http/common"
-    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/aks-middleware/http/common"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {
-    Logger    *slog.Logger
-    StartTime time.Time
-    Request   interface{}
-    Response  *http.Response
-    Error     error
+	Logger    *slog.Logger
+	StartTime time.Time
+	Request   interface{}
+	Response  *http.Response
+	Error     error
 }
 
 func trimToSubscription(rawURL string) string {
-    // Find the index of "/subscriptions"
-    if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
-        return rawURL[idx:]
-    }
-    return rawURL
+	// Find the index of "/subscriptions"
+	if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
+		return rawURL[idx:]
+	}
+	return rawURL
 }
 
 func sanitizeResourceType(rt string, rawURL string) string {
-    // Keep only the substring after the last slash.
-    if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
-        rt = rt[idx+1:]
-    }
-    // Remove everything after the first '?'.
-    if idx := strings.Index(rt, "?"); idx != -1 {
-        rt = rt[:idx]
-    }
-    rt = strings.ToLower(rt)
+	// Keep only the substring after the last slash.
+	if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
+		rt = rt[idx+1:]
+	}
+	// Remove everything after the first '?'.
+	if idx := strings.Index(rt, "?"); idx != -1 {
+		rt = rt[:idx]
+	}
+	rt = strings.ToLower(rt)
 
-    return rt
+	return rt
 }
 
 func GetMethodInfo(method string, rawURL string) string {
-    // Trim the URL to ensure it starts with "/subscriptions"
-    validURL := trimToSubscription(rawURL)
+	// Trim the URL to ensure it starts with "/subscriptions"
+	validURL := trimToSubscription(rawURL)
 
-    // First, try to parse validURL as a full resource ID.
-    id, err := arm.ParseResourceID(validURL)
-    if err != nil {
-        // Retry by appending a false resource name ("dummy")
-        // To be a valid resource ID, the URL must end with the resource name.
-        fakeURL := validURL
-        if !strings.HasSuffix(validURL, "/dummy") {
-            fakeURL = validURL + "/dummy"
-        }
-        id, err = arm.ParseResourceID(fakeURL)
-        if err != nil {
-            // Fallback: if parsing still fails, use the full URL but remove api-version.
-            // This is to avoid providing aggregated data for each api version in dashboards
-            // Full URL can still be found in the logs
-            cleanedURL := CleanURL(rawURL)
-            return method + " " + cleanedURL
-        }
-        // We know a fake resource name was added.
-        if method == "GET" {
-            // For GET requests with a fake name, we assume it's a list operation.
-            return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
-        }
-        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
-    }
+	// First, try to parse validURL as a full resource ID.
+	id, err := arm.ParseResourceID(validURL)
+	if err != nil {
+		// Retry by appending a false resource name ("dummy")
+		// To be a valid resource ID, the URL must end with the resource name.
+		fakeURL := validURL
+		if !strings.HasSuffix(validURL, "/dummy") {
+			fakeURL = validURL + "/dummy"
+		}
+		id, err = arm.ParseResourceID(fakeURL)
+		if err != nil {
+			// Fallback: if parsing still fails, use the full URL (minus query params and api version).
+			// This is to avoid providing aggregated data for each api version/param in dashboards
+			// Full URL can still be found in the logs
+			return method + " " + rawURL
+		}
+		// We know a fake resource name was added.
+		if method == "GET" {
+			// For GET requests with a fake name, we assume it's a list operation.
+			return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
+		}
+		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+	}
 
-    // If parsing was successful on the first try.
-    if method == "GET" {
-        op := " - READ"
-        if strings.TrimSpace(id.Name) == "" {
-            op = " - LIST"
-        }
-        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
-    }
-    return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+	// If parsing was successful on the first try.
+	if method == "GET" {
+		op := " - READ"
+		if strings.TrimSpace(id.Name) == "" {
+			op = " - LIST"
+		}
+		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
+	}
+	return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
 }
 
 func TrimURL(parsedURL url.URL) string {
-    // Extract the `api-version` parameter
-    apiVersion := parsedURL.Query().Get("api-version")
+	// Reconstruct the URL with only the `api-version` parameter, removing any other query parameters.
+	baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
 
-    // Reconstruct the URL with only the `api-version` parameter
-    baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
-    if apiVersion != "" {
-        return baseURL + "?api-version=" + apiVersion
-    }
-    return baseURL
-}
-
-func CleanURL(rawURL string) string {
-    // Find the index of "api-version=" in the URL
-    apiVersionIndex := strings.Index(rawURL, "api-version=")
-
-    // If api-version is not found, return the original URL
-    if apiVersionIndex == -1 {
-        return rawURL
-    }
-
-    // Find the character that comes before "api-version="
-    // It could be either "?" (if it's the first parameter) or "&" (if it comes after other parameters)
-    separatorIndex := -1
-    if apiVersionIndex > 0 {
-        if rawURL[apiVersionIndex-1] == '?' {
-            separatorIndex = apiVersionIndex - 1
-        } else if rawURL[apiVersionIndex-1] == '&' {
-            separatorIndex = apiVersionIndex - 1
-        }
-    }
-
-    // If a separator was found, truncate the URL at that point
-    // this is to prevent additional query params from being included in the aggregated data on dashboards
-    if separatorIndex != -1 {
-        return rawURL[:separatorIndex]
-    }
-
-    return rawURL
+	return baseURL
 }
 
 func LogRequest(params LogRequestParams) {
-    var method, service, reqURL string
-    switch req := params.Request.(type) {
-    case *http.Request:
-        method = req.Method
-        service = req.Host
-        reqURL = req.URL.String()
+	var method, service, reqURL string
+	switch req := params.Request.(type) {
+	case *http.Request:
+		method = req.Method
+		service = req.Host
+		reqURL = req.URL.String()
 
-    case *azcorePolicy.Request:
-        method = req.Raw().Method
-        service = req.Raw().Host
-        reqURL = req.Raw().URL.String()
-    default:
-        return // Unknown request type, do nothing
-    }
+	case *azcorePolicy.Request:
+		method = req.Raw().Method
+		service = req.Raw().Host
+		reqURL = req.Raw().URL.String()
+	default:
+		return // Unknown request type, do nothing
+	}
 
-    parsedURL, parseErr := url.Parse(reqURL)
-    if parseErr != nil {
-        params.Logger.With(
-            "source", "ApiRequestLog",
-            "protocol", "REST",
-            "method_type", "unary",
-            "code", "na",
-            "component", "client",
-            "time_ms", "na",
-            "method", method,
-            "service", service,
-            "url", reqURL,
-            "error", parseErr.Error(),
-        ).Error("error parsing request URL")
-    } else {
-        reqURL = TrimURL(*parsedURL)
-    }
+	parsedURL, parseErr := url.Parse(reqURL)
+	if parseErr != nil {
+		params.Logger.With(
+			"source", "ApiRequestLog",
+			"protocol", "REST",
+			"method_type", "unary",
+			"code", "na",
+			"component", "client",
+			"time_ms", "na",
+			"method", method,
+			"service", service,
+			"url", reqURL,
+			"error", parseErr.Error(),
+		).Error("error parsing request URL")
+	} else {
+		reqURL = TrimURL(*parsedURL)
+	}
 
-    methodInfo := GetMethodInfo(method, reqURL)
-    latency := time.Since(params.StartTime).Milliseconds()
+	methodInfo := GetMethodInfo(method, reqURL)
+	latency := time.Since(params.StartTime).Milliseconds()
 
-    var headers map[string]string
-    if params.Response != nil {
-        headers = extractHeaders(params.Response.Header)
-    }
+	var headers map[string]string
+	if params.Response != nil {
+		headers = extractHeaders(params.Response.Header)
+	}
 
-    logEntry := params.Logger.With(
-        "source", "ApiRequestLog",
-        "protocol", "REST",
-        "method_type", "unary",
-        "component", "client",
-        "time_ms", latency,
-        "method", methodInfo,
-        "service", service,
-        "url", reqURL,
-        "headers", headers,
-    )
+	logEntry := params.Logger.With(
+		"source", "ApiRequestLog",
+		"protocol", "REST",
+		"method_type", "unary",
+		"component", "client",
+		"time_ms", latency,
+		"method", methodInfo,
+		"service", service,
+		"url", reqURL,
+		"headers", headers,
+	)
 
-    if params.Error != nil || params.Response == nil {
-        logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
-    } else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
-        logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
-    } else {
-        logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
-    }
+	if params.Error != nil || params.Response == nil {
+		logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
+	} else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
+		logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
+	} else {
+		logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
+	}
 }
 
 func extractHeaders(header http.Header) map[string]string {
-    headers := make(map[string]string)
+	headers := make(map[string]string)
 
-    // List of headers to extract
-    headerKeys := []string{
-        common.RequestCorrelationIDHeader,
-        common.RequestAcsOperationIDHeader,
-        common.RequestARMClientRequestIDHeader,
-    }
+	// List of headers to extract
+	headerKeys := []string{
+		common.RequestCorrelationIDHeader,
+		common.RequestAcsOperationIDHeader,
+		common.RequestARMClientRequestIDHeader,
+	}
 
-    // Convert header keys to lowercase
-    lowerHeader := make(http.Header)
-    for key, values := range header {
-        lowerHeader[strings.ToLower(key)] = values
-    }
+	// Convert header keys to lowercase
+	lowerHeader := make(http.Header)
+	for key, values := range header {
+		lowerHeader[strings.ToLower(key)] = values
+	}
 
-    for _, key := range headerKeys {
-        lowerKey := strings.ToLower(key)
-        if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
-            headers[key] = values[0]
-        }
-    }
+	for _, key := range headerKeys {
+		lowerKey := strings.ToLower(key)
+		if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
+			headers[key] = values[0]
+		}
+	}
 
-    return headers
+	return headers
 }
 
 // ResponseWriter is a custom response writer that buffers the response body and tracks the status code.
 type ResponseWriter struct {
-    http.ResponseWriter
-    StatusCode int
-    Buf        *bytes.Buffer
+	http.ResponseWriter
+	StatusCode int
+	Buf        *bytes.Buffer
 }
 
 func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
-    return &ResponseWriter{
-        ResponseWriter: w,
-        Buf:            new(bytes.Buffer),
-    }
+	return &ResponseWriter{
+		ResponseWriter: w,
+		Buf:            new(bytes.Buffer),
+	}
 }
 
 func (w *ResponseWriter) WriteHeader(code int) {
-    w.StatusCode = code
-    w.ResponseWriter.WriteHeader(code)
+	w.StatusCode = code
+	w.ResponseWriter.WriteHeader(code)
 }
 
 func (w *ResponseWriter) Write(b []byte) (int, error) {
-    if w.StatusCode == 0 {
-        w.StatusCode = http.StatusOK
-    }
-    if w.StatusCode >= http.StatusBadRequest {
-        if w.Buf == nil {
-            w.Buf = new(bytes.Buffer)
-        }
-        // Write only if status code indicates error
-        w.Buf.Write(b)
-    }
-    return w.ResponseWriter.Write(b)
+	if w.StatusCode == 0 {
+		w.StatusCode = http.StatusOK
+	}
+	if w.StatusCode >= http.StatusBadRequest {
+		if w.Buf == nil {
+			w.Buf = new(bytes.Buffer)
+		}
+		// Write only if status code indicates error
+		w.Buf.Write(b)
+	}
+	return w.ResponseWriter.Write(b)
 }

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,212 +1,212 @@
 package logging
 
 import (
-	"bytes"
-	"log/slog"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+    "bytes"
+    "log/slog"
+    "net/http"
+    "net/url"
+    "strings"
+    "time"
 
-	"github.com/Azure/aks-middleware/http/common"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+    "github.com/Azure/aks-middleware/http/common"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {
-	Logger    *slog.Logger
-	StartTime time.Time
-	Request   interface{}
-	Response  *http.Response
-	Error     error
+    Logger    *slog.Logger
+    StartTime time.Time
+    Request   interface{}
+    Response  *http.Response
+    Error     error
 }
 
 func trimToSubscription(rawURL string) string {
-	// Find the index of "/subscriptions"
-	if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
-		return rawURL[idx:]
-	}
-	return rawURL
+    // Find the index of "/subscriptions"
+    if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
+        return rawURL[idx:]
+    }
+    return rawURL
 }
 
 func sanitizeResourceType(rt string, rawURL string) string {
-	// Keep only the substring after the last slash.
-	if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
-		rt = rt[idx+1:]
-	}
-	// Remove everything after the first '?'.
-	if idx := strings.Index(rt, "?"); idx != -1 {
-		rt = rt[:idx]
-	}
-	rt = strings.ToLower(rt)
+    // Keep only the substring after the last slash.
+    if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
+        rt = rt[idx+1:]
+    }
+    // Remove everything after the first '?'.
+    if idx := strings.Index(rt, "?"); idx != -1 {
+        rt = rt[:idx]
+    }
+    rt = strings.ToLower(rt)
 
-	return rt
+    return rt
 }
 
 func GetMethodInfo(method string, rawURL string) string {
-	// Trim the URL to ensure it starts with "/subscriptions"
-	validURL := trimToSubscription(rawURL)
+    // Trim the URL to ensure it starts with "/subscriptions"
+    validURL := trimToSubscription(rawURL)
 
-	// First, try to parse validURL as a full resource ID.
-	id, err := arm.ParseResourceID(validURL)
-	if err != nil {
-		// Retry by appending a false resource name ("dummy")
-		// To be a valid resource ID, the URL must end with the resource name.
-		fakeURL := validURL
-		if !strings.HasSuffix(validURL, "/dummy") {
-			fakeURL = validURL + "/dummy"
-		}
-		id, err = arm.ParseResourceID(fakeURL)
-		if err != nil {
-			// Fallback: if parsing still fails, use the full URL (minus query params and api version).
-			// This is to avoid providing aggregated data for each api version/param in dashboards
-			// Full URL can still be found in the logs
-			return method + " " + rawURL
-		}
-		// We know a fake resource name was added.
-		if method == "GET" {
-			// For GET requests with a fake name, we assume it's a list operation.
-			return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
-		}
-		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
-	}
+    // First, try to parse validURL as a full resource ID.
+    id, err := arm.ParseResourceID(validURL)
+    if err != nil {
+        // Retry by appending a false resource name ("dummy")
+        // To be a valid resource ID, the URL must end with the resource name.
+        fakeURL := validURL
+        if !strings.HasSuffix(validURL, "/dummy") {
+            fakeURL = validURL + "/dummy"
+        }
+        id, err = arm.ParseResourceID(fakeURL)
+        if err != nil {
+            // Fallback: if parsing still fails, use the full URL (minus query params and api version).
+            // This is to avoid providing aggregated data for each api version/param in dashboards
+            // Full URL can still be found in the logs
+            return method + " " + rawURL
+        }
+        // We know a fake resource name was added.
+        if method == "GET" {
+            // For GET requests with a fake name, we assume it's a list operation.
+            return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
+        }
+        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+    }
 
-	// If parsing was successful on the first try.
-	if method == "GET" {
-		op := " - READ"
-		if strings.TrimSpace(id.Name) == "" {
-			op = " - LIST"
-		}
-		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
-	}
-	return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+    // If parsing was successful on the first try.
+    if method == "GET" {
+        op := " - READ"
+        if strings.TrimSpace(id.Name) == "" {
+            op = " - LIST"
+        }
+        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
+    }
+    return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
 }
 
 func TrimURL(parsedURL url.URL) string {
-	// Reconstruct the URL with only the `api-version` parameter, removing any other query parameters.
-	baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
+    // Reconstruct the URL with only the `api-version` parameter, removing any other query parameters.
+    baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
 
-	return baseURL
+    return baseURL
 }
 
 func LogRequest(params LogRequestParams) {
-	var method, service, reqURL string
-	switch req := params.Request.(type) {
-	case *http.Request:
-		method = req.Method
-		service = req.Host
-		reqURL = req.URL.String()
+    var method, service, reqURL string
+    switch req := params.Request.(type) {
+    case *http.Request:
+        method = req.Method
+        service = req.Host
+        reqURL = req.URL.String()
 
-	case *azcorePolicy.Request:
-		method = req.Raw().Method
-		service = req.Raw().Host
-		reqURL = req.Raw().URL.String()
-	default:
-		return // Unknown request type, do nothing
-	}
+    case *azcorePolicy.Request:
+        method = req.Raw().Method
+        service = req.Raw().Host
+        reqURL = req.Raw().URL.String()
+    default:
+        return // Unknown request type, do nothing
+    }
 
-	parsedURL, parseErr := url.Parse(reqURL)
-	if parseErr != nil {
-		params.Logger.With(
-			"source", "ApiRequestLog",
-			"protocol", "REST",
-			"method_type", "unary",
-			"code", "na",
-			"component", "client",
-			"time_ms", "na",
-			"method", method,
-			"service", service,
-			"url", reqURL,
-			"error", parseErr.Error(),
-		).Error("error parsing request URL")
-	} else {
-		reqURL = TrimURL(*parsedURL)
-	}
+    parsedURL, parseErr := url.Parse(reqURL)
+    if parseErr != nil {
+        params.Logger.With(
+            "source", "ApiRequestLog",
+            "protocol", "REST",
+            "method_type", "unary",
+            "code", "na",
+            "component", "client",
+            "time_ms", "na",
+            "method", method,
+            "service", service,
+            "url", reqURL,
+            "error", parseErr.Error(),
+        ).Error("error parsing request URL")
+    } else {
+        reqURL = TrimURL(*parsedURL)
+    }
 
-	methodInfo := GetMethodInfo(method, reqURL)
-	latency := time.Since(params.StartTime).Milliseconds()
+    methodInfo := GetMethodInfo(method, reqURL)
+    latency := time.Since(params.StartTime).Milliseconds()
 
-	var headers map[string]string
-	if params.Response != nil {
-		headers = extractHeaders(params.Response.Header)
-	}
+    var headers map[string]string
+    if params.Response != nil {
+        headers = extractHeaders(params.Response.Header)
+    }
 
-	logEntry := params.Logger.With(
-		"source", "ApiRequestLog",
-		"protocol", "REST",
-		"method_type", "unary",
-		"component", "client",
-		"time_ms", latency,
-		"method", methodInfo,
-		"service", service,
-		"url", reqURL,
-		"headers", headers,
-	)
+    logEntry := params.Logger.With(
+        "source", "ApiRequestLog",
+        "protocol", "REST",
+        "method_type", "unary",
+        "component", "client",
+        "time_ms", latency,
+        "method", methodInfo,
+        "service", service,
+        "url", reqURL,
+        "headers", headers,
+    )
 
-	if params.Error != nil || params.Response == nil {
-		logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
-	} else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
-		logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
-	} else {
-		logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
-	}
+    if params.Error != nil || params.Response == nil {
+        logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
+    } else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
+        logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
+    } else {
+        logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
+    }
 }
 
 func extractHeaders(header http.Header) map[string]string {
-	headers := make(map[string]string)
+    headers := make(map[string]string)
 
-	// List of headers to extract
-	headerKeys := []string{
-		common.RequestCorrelationIDHeader,
-		common.RequestAcsOperationIDHeader,
-		common.RequestARMClientRequestIDHeader,
-	}
+    // List of headers to extract
+    headerKeys := []string{
+        common.RequestCorrelationIDHeader,
+        common.RequestAcsOperationIDHeader,
+        common.RequestARMClientRequestIDHeader,
+    }
 
-	// Convert header keys to lowercase
-	lowerHeader := make(http.Header)
-	for key, values := range header {
-		lowerHeader[strings.ToLower(key)] = values
-	}
+    // Convert header keys to lowercase
+    lowerHeader := make(http.Header)
+    for key, values := range header {
+        lowerHeader[strings.ToLower(key)] = values
+    }
 
-	for _, key := range headerKeys {
-		lowerKey := strings.ToLower(key)
-		if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
-			headers[key] = values[0]
-		}
-	}
+    for _, key := range headerKeys {
+        lowerKey := strings.ToLower(key)
+        if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
+            headers[key] = values[0]
+        }
+    }
 
-	return headers
+    return headers
 }
 
 // ResponseWriter is a custom response writer that buffers the response body and tracks the status code.
 type ResponseWriter struct {
-	http.ResponseWriter
-	StatusCode int
-	Buf        *bytes.Buffer
+    http.ResponseWriter
+    StatusCode int
+    Buf        *bytes.Buffer
 }
 
 func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
-	return &ResponseWriter{
-		ResponseWriter: w,
-		Buf:            new(bytes.Buffer),
-	}
+    return &ResponseWriter{
+        ResponseWriter: w,
+        Buf:            new(bytes.Buffer),
+    }
 }
 
 func (w *ResponseWriter) WriteHeader(code int) {
-	w.StatusCode = code
-	w.ResponseWriter.WriteHeader(code)
+    w.StatusCode = code
+    w.ResponseWriter.WriteHeader(code)
 }
 
 func (w *ResponseWriter) Write(b []byte) (int, error) {
-	if w.StatusCode == 0 {
-		w.StatusCode = http.StatusOK
-	}
-	if w.StatusCode >= http.StatusBadRequest {
-		if w.Buf == nil {
-			w.Buf = new(bytes.Buffer)
-		}
-		// Write only if status code indicates error
-		w.Buf.Write(b)
-	}
-	return w.ResponseWriter.Write(b)
+    if w.StatusCode == 0 {
+        w.StatusCode = http.StatusOK
+    }
+    if w.StatusCode >= http.StatusBadRequest {
+        if w.Buf == nil {
+            w.Buf = new(bytes.Buffer)
+        }
+        // Write only if status code indicates error
+        w.Buf.Write(b)
+    }
+    return w.ResponseWriter.Write(b)
 }

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,247 +1,247 @@
 package logging
 
 import (
-	"bytes"
-	"log/slog"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+    "bytes"
+    "log/slog"
+    "net/http"
+    "net/url"
+    "strings"
+    "time"
 
-	"github.com/Azure/aks-middleware/http/common"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+    "github.com/Azure/aks-middleware/http/common"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {
-	Logger    *slog.Logger
-	StartTime time.Time
-	Request   interface{}
-	Response  *http.Response
-	Error     error
+    Logger    *slog.Logger
+    StartTime time.Time
+    Request   interface{}
+    Response  *http.Response
+    Error     error
 }
 
 func trimToSubscription(rawURL string) string {
-	// Find the index of "/subscriptions"
-	if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
-		return rawURL[idx:]
-	}
-	return rawURL
+    // Find the index of "/subscriptions"
+    if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
+        return rawURL[idx:]
+    }
+    return rawURL
 }
 
 func sanitizeResourceType(rt string, rawURL string) string {
-	// Keep only the substring after the last slash.
-	if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
-		rt = rt[idx+1:]
-	}
-	// Remove everything after the first '?'.
-	if idx := strings.Index(rt, "?"); idx != -1 {
-		rt = rt[:idx]
-	}
-	rt = strings.ToLower(rt)
+    // Keep only the substring after the last slash.
+    if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
+        rt = rt[idx+1:]
+    }
+    // Remove everything after the first '?'.
+    if idx := strings.Index(rt, "?"); idx != -1 {
+        rt = rt[:idx]
+    }
+    rt = strings.ToLower(rt)
 
-	return rt
+    return rt
 }
 
 func GetMethodInfo(method string, rawURL string) string {
-	// Trim the URL to ensure it starts with "/subscriptions"
-	validURL := trimToSubscription(rawURL)
+    // Trim the URL to ensure it starts with "/subscriptions"
+    validURL := trimToSubscription(rawURL)
 
-	// First, try to parse validURL as a full resource ID.
-	id, err := arm.ParseResourceID(validURL)
-	if err != nil {
-		// Retry by appending a false resource name ("dummy")
-		// To be a valid resource ID, the URL must end with the resource name.
-		fakeURL := validURL
-		if !strings.HasSuffix(validURL, "/dummy") {
-			fakeURL = validURL + "/dummy"
-		}
-		id, err = arm.ParseResourceID(fakeURL)
-		if err != nil {
-			// Fallback: if parsing still fails, use the full URL but remove api-version.
-			// This is to avoid providing aggregated data for each api version in dashboards
-			// Full URL can still be found in the logs
-			cleanedURL := CleanURL(rawURL)
-			return method + " " + cleanedURL
-		}
-		// We know a fake resource name was added.
-		if method == "GET" {
-			// For GET requests with a fake name, we assume it's a list operation.
-			return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
-		}
-		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
-	}
+    // First, try to parse validURL as a full resource ID.
+    id, err := arm.ParseResourceID(validURL)
+    if err != nil {
+        // Retry by appending a false resource name ("dummy")
+        // To be a valid resource ID, the URL must end with the resource name.
+        fakeURL := validURL
+        if !strings.HasSuffix(validURL, "/dummy") {
+            fakeURL = validURL + "/dummy"
+        }
+        id, err = arm.ParseResourceID(fakeURL)
+        if err != nil {
+            // Fallback: if parsing still fails, use the full URL but remove api-version.
+            // This is to avoid providing aggregated data for each api version in dashboards
+            // Full URL can still be found in the logs
+            cleanedURL := CleanURL(rawURL)
+            return method + " " + cleanedURL
+        }
+        // We know a fake resource name was added.
+        if method == "GET" {
+            // For GET requests with a fake name, we assume it's a list operation.
+            return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
+        }
+        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+    }
 
-	// If parsing was successful on the first try.
-	if method == "GET" {
-		op := " - READ"
-		if strings.TrimSpace(id.Name) == "" {
-			op = " - LIST"
-		}
-		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
-	}
-	return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+    // If parsing was successful on the first try.
+    if method == "GET" {
+        op := " - READ"
+        if strings.TrimSpace(id.Name) == "" {
+            op = " - LIST"
+        }
+        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
+    }
+    return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
 }
 
 func TrimURL(parsedURL url.URL) string {
-	// Extract the `api-version` parameter
-	apiVersion := parsedURL.Query().Get("api-version")
+    // Extract the `api-version` parameter
+    apiVersion := parsedURL.Query().Get("api-version")
 
-	// Reconstruct the URL with only the `api-version` parameter
-	baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
-	if apiVersion != "" {
-		return baseURL + "?api-version=" + apiVersion
-	}
-	return baseURL
+    // Reconstruct the URL with only the `api-version` parameter
+    baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
+    if apiVersion != "" {
+        return baseURL + "?api-version=" + apiVersion
+    }
+    return baseURL
 }
 
 func CleanURL(rawURL string) string {
-	// Find the index of "api-version=" in the URL
-	apiVersionIndex := strings.Index(rawURL, "api-version=")
+    // Find the index of "api-version=" in the URL
+    apiVersionIndex := strings.Index(rawURL, "api-version=")
 
-	// If api-version is not found, return the original URL
-	if apiVersionIndex == -1 {
-		return rawURL
-	}
+    // If api-version is not found, return the original URL
+    if apiVersionIndex == -1 {
+        return rawURL
+    }
 
-	// Find the character that comes before "api-version="
-	// It could be either "?" (if it's the first parameter) or "&" (if it comes after other parameters)
-	separatorIndex := -1
-	if apiVersionIndex > 0 {
-		if rawURL[apiVersionIndex-1] == '?' {
-			separatorIndex = apiVersionIndex - 1
-		} else if rawURL[apiVersionIndex-1] == '&' {
-			separatorIndex = apiVersionIndex - 1
-		}
-	}
+    // Find the character that comes before "api-version="
+    // It could be either "?" (if it's the first parameter) or "&" (if it comes after other parameters)
+    separatorIndex := -1
+    if apiVersionIndex > 0 {
+        if rawURL[apiVersionIndex-1] == '?' {
+            separatorIndex = apiVersionIndex - 1
+        } else if rawURL[apiVersionIndex-1] == '&' {
+            separatorIndex = apiVersionIndex - 1
+        }
+    }
 
-	// If a separator was found, truncate the URL at that point
-	// this is to prevent additional query params from being included in the aggregated data on dashboards
-	if separatorIndex != -1 {
-		return rawURL[:separatorIndex]
-	}
+    // If a separator was found, truncate the URL at that point
+    // this is to prevent additional query params from being included in the aggregated data on dashboards
+    if separatorIndex != -1 {
+        return rawURL[:separatorIndex]
+    }
 
-	return rawURL
+    return rawURL
 }
 
 func LogRequest(params LogRequestParams) {
-	var method, service, reqURL string
-	switch req := params.Request.(type) {
-	case *http.Request:
-		method = req.Method
-		service = req.Host
-		reqURL = req.URL.String()
+    var method, service, reqURL string
+    switch req := params.Request.(type) {
+    case *http.Request:
+        method = req.Method
+        service = req.Host
+        reqURL = req.URL.String()
 
-	case *azcorePolicy.Request:
-		method = req.Raw().Method
-		service = req.Raw().Host
-		reqURL = req.Raw().URL.String()
-	default:
-		return // Unknown request type, do nothing
-	}
+    case *azcorePolicy.Request:
+        method = req.Raw().Method
+        service = req.Raw().Host
+        reqURL = req.Raw().URL.String()
+    default:
+        return // Unknown request type, do nothing
+    }
 
-	parsedURL, parseErr := url.Parse(reqURL)
-	if parseErr != nil {
-		params.Logger.With(
-			"source", "ApiRequestLog",
-			"protocol", "REST",
-			"method_type", "unary",
-			"code", "na",
-			"component", "client",
-			"time_ms", "na",
-			"method", method,
-			"service", service,
-			"url", reqURL,
-			"error", parseErr.Error(),
-		).Error("error parsing request URL")
-	} else {
-		reqURL = TrimURL(*parsedURL)
-	}
+    parsedURL, parseErr := url.Parse(reqURL)
+    if parseErr != nil {
+        params.Logger.With(
+            "source", "ApiRequestLog",
+            "protocol", "REST",
+            "method_type", "unary",
+            "code", "na",
+            "component", "client",
+            "time_ms", "na",
+            "method", method,
+            "service", service,
+            "url", reqURL,
+            "error", parseErr.Error(),
+        ).Error("error parsing request URL")
+    } else {
+        reqURL = TrimURL(*parsedURL)
+    }
 
-	methodInfo := GetMethodInfo(method, reqURL)
-	latency := time.Since(params.StartTime).Milliseconds()
+    methodInfo := GetMethodInfo(method, reqURL)
+    latency := time.Since(params.StartTime).Milliseconds()
 
-	var headers map[string]string
-	if params.Response != nil {
-		headers = extractHeaders(params.Response.Header)
-	}
+    var headers map[string]string
+    if params.Response != nil {
+        headers = extractHeaders(params.Response.Header)
+    }
 
-	logEntry := params.Logger.With(
-		"source", "ApiRequestLog",
-		"protocol", "REST",
-		"method_type", "unary",
-		"component", "client",
-		"time_ms", latency,
-		"method", methodInfo,
-		"service", service,
-		"url", reqURL,
-		"headers", headers,
-	)
+    logEntry := params.Logger.With(
+        "source", "ApiRequestLog",
+        "protocol", "REST",
+        "method_type", "unary",
+        "component", "client",
+        "time_ms", latency,
+        "method", methodInfo,
+        "service", service,
+        "url", reqURL,
+        "headers", headers,
+    )
 
-	if params.Error != nil || params.Response == nil {
-		logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
-	} else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
-		logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
-	} else {
-		logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
-	}
+    if params.Error != nil || params.Response == nil {
+        logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
+    } else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
+        logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
+    } else {
+        logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
+    }
 }
 
 func extractHeaders(header http.Header) map[string]string {
-	headers := make(map[string]string)
+    headers := make(map[string]string)
 
-	// List of headers to extract
-	headerKeys := []string{
-		common.RequestCorrelationIDHeader,
-		common.RequestAcsOperationIDHeader,
-		common.RequestARMClientRequestIDHeader,
-	}
+    // List of headers to extract
+    headerKeys := []string{
+        common.RequestCorrelationIDHeader,
+        common.RequestAcsOperationIDHeader,
+        common.RequestARMClientRequestIDHeader,
+    }
 
-	// Convert header keys to lowercase
-	lowerHeader := make(http.Header)
-	for key, values := range header {
-		lowerHeader[strings.ToLower(key)] = values
-	}
+    // Convert header keys to lowercase
+    lowerHeader := make(http.Header)
+    for key, values := range header {
+        lowerHeader[strings.ToLower(key)] = values
+    }
 
-	for _, key := range headerKeys {
-		lowerKey := strings.ToLower(key)
-		if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
-			headers[key] = values[0]
-		}
-	}
+    for _, key := range headerKeys {
+        lowerKey := strings.ToLower(key)
+        if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
+            headers[key] = values[0]
+        }
+    }
 
-	return headers
+    return headers
 }
 
 // ResponseWriter is a custom response writer that buffers the response body and tracks the status code.
 type ResponseWriter struct {
-	http.ResponseWriter
-	StatusCode int
-	Buf        *bytes.Buffer
+    http.ResponseWriter
+    StatusCode int
+    Buf        *bytes.Buffer
 }
 
 func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
-	return &ResponseWriter{
-		ResponseWriter: w,
-		Buf:            new(bytes.Buffer),
-	}
+    return &ResponseWriter{
+        ResponseWriter: w,
+        Buf:            new(bytes.Buffer),
+    }
 }
 
 func (w *ResponseWriter) WriteHeader(code int) {
-	w.StatusCode = code
-	w.ResponseWriter.WriteHeader(code)
+    w.StatusCode = code
+    w.ResponseWriter.WriteHeader(code)
 }
 
 func (w *ResponseWriter) Write(b []byte) (int, error) {
-	if w.StatusCode == 0 {
-		w.StatusCode = http.StatusOK
-	}
-	if w.StatusCode >= http.StatusBadRequest {
-		if w.Buf == nil {
-			w.Buf = new(bytes.Buffer)
-		}
-		// Write only if status code indicates error
-		w.Buf.Write(b)
-	}
-	return w.ResponseWriter.Write(b)
+    if w.StatusCode == 0 {
+        w.StatusCode = http.StatusOK
+    }
+    if w.StatusCode >= http.StatusBadRequest {
+        if w.Buf == nil {
+            w.Buf = new(bytes.Buffer)
+        }
+        // Write only if status code indicates error
+        w.Buf.Write(b)
+    }
+    return w.ResponseWriter.Write(b)
 }

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,16 +1,16 @@
 package logging
 
 import (
-    "bytes"
-    "log/slog"
-    "net/http"
-    "net/url"
-    "strings"
-    "time"
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-    "github.com/Azure/aks-middleware/http/common"
-    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/aks-middleware/http/common"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {
@@ -60,7 +60,6 @@ func GetMethodInfo(method string, rawURL string) string {
         if err != nil {
             // Fallback: if parsing still fails, use the full URL (minus query params and api version).
             // This is to avoid providing aggregated data for each api version/param in dashboards
-            // Full URL can still be found in the logs
             return method + " " + rawURL
         }
         // We know a fake resource name was added.
@@ -83,7 +82,7 @@ func GetMethodInfo(method string, rawURL string) string {
 }
 
 func TrimURL(parsedURL url.URL) string {
-    // Reconstruct the URL with only the `api-version` parameter, removing any other query parameters.
+    // Reconstruct the URL without `api-version` parameter and any other query parameters.
     baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
 
     return baseURL

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,215 +1,247 @@
 package logging
 
 import (
-    "bytes"
-    "log/slog"
-    "net/http"
-    "net/url"
-    "strings"
-    "time"
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-    "github.com/Azure/aks-middleware/http/common"
-    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/aks-middleware/http/common"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {
-    Logger    *slog.Logger
-    StartTime time.Time
-    Request   interface{}
-    Response  *http.Response
-    Error     error
+	Logger    *slog.Logger
+	StartTime time.Time
+	Request   interface{}
+	Response  *http.Response
+	Error     error
 }
 
 func trimToSubscription(rawURL string) string {
-    // Find the index of "/subscriptions"
-    if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
-        return rawURL[idx:]
-    }
-    return rawURL
+	// Find the index of "/subscriptions"
+	if idx := strings.Index(rawURL, "/subscriptions"); idx != -1 {
+		return rawURL[idx:]
+	}
+	return rawURL
 }
 
 func sanitizeResourceType(rt string, rawURL string) string {
-    // Keep only the substring after the last slash.
-    if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
-        rt = rt[idx+1:]
-    }
-    // Remove everything after the first '?'.
-    if idx := strings.Index(rt, "?"); idx != -1 {
-        rt = rt[:idx]
-    }
-    rt = strings.ToLower(rt)
+	// Keep only the substring after the last slash.
+	if idx := strings.LastIndex(rt, "/"); idx != -1 && idx < len(rt)-1 {
+		rt = rt[idx+1:]
+	}
+	// Remove everything after the first '?'.
+	if idx := strings.Index(rt, "?"); idx != -1 {
+		rt = rt[:idx]
+	}
+	rt = strings.ToLower(rt)
 
-    return rt
+	return rt
 }
 
 func GetMethodInfo(method string, rawURL string) string {
-    // Trim the URL to ensure it starts with "/subscriptions"
-    validURL := trimToSubscription(rawURL)
+	// Trim the URL to ensure it starts with "/subscriptions"
+	validURL := trimToSubscription(rawURL)
 
-    // First, try to parse validURL as a full resource ID.
-    id, err := arm.ParseResourceID(validURL)
-    if err != nil {
-        // Retry by appending a false resource name ("dummy")
-        // To be a valid resource ID, the URL must end with the resource name.
-        fakeURL := validURL
-        if !strings.HasSuffix(validURL, "/dummy") {
-            fakeURL = validURL + "/dummy"
-        }
-        id, err = arm.ParseResourceID(fakeURL)
-        if err != nil {
-            // Fallback: if parsing still fails, use the full URL.
-            return method + " " + rawURL
-        }
-        // We know a fake resource name was added.
-        if method == "GET" {
-            // For GET requests with a fake name, we assume it's a list operation.
-            return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
-        }
-        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
-    }
+	// First, try to parse validURL as a full resource ID.
+	id, err := arm.ParseResourceID(validURL)
+	if err != nil {
+		// Retry by appending a false resource name ("dummy")
+		// To be a valid resource ID, the URL must end with the resource name.
+		fakeURL := validURL
+		if !strings.HasSuffix(validURL, "/dummy") {
+			fakeURL = validURL + "/dummy"
+		}
+		id, err = arm.ParseResourceID(fakeURL)
+		if err != nil {
+			// Fallback: if parsing still fails, use the full URL but remove api-version.
+			// This is to avoid providing aggregated data for each api version in dashboards
+			// Full URL can still be found in the logs
+			cleanedURL := CleanURL(rawURL)
+			return method + " " + cleanedURL
+		}
+		// We know a fake resource name was added.
+		if method == "GET" {
+			// For GET requests with a fake name, we assume it's a list operation.
+			return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + " - LIST"
+		}
+		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+	}
 
-    // If parsing was successful on the first try.
-    if method == "GET" {
-        op := " - READ"
-        if strings.TrimSpace(id.Name) == "" {
-            op = " - LIST"
-        }
-        return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
-    }
-    return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
+	// If parsing was successful on the first try.
+	if method == "GET" {
+		op := " - READ"
+		if strings.TrimSpace(id.Name) == "" {
+			op = " - LIST"
+		}
+		return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL) + op
+	}
+	return method + " " + sanitizeResourceType(id.ResourceType.String(), rawURL)
 }
 
 func TrimURL(parsedURL url.URL) string {
-    // Extract the `api-version` parameter
-    apiVersion := parsedURL.Query().Get("api-version")
+	// Extract the `api-version` parameter
+	apiVersion := parsedURL.Query().Get("api-version")
 
-    // Reconstruct the URL with only the `api-version` parameter
-    baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
-    if apiVersion != "" {
-        return baseURL + "?api-version=" + apiVersion
-    }
-    return baseURL
+	// Reconstruct the URL with only the `api-version` parameter
+	baseURL := parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
+	if apiVersion != "" {
+		return baseURL + "?api-version=" + apiVersion
+	}
+	return baseURL
+}
+
+func CleanURL(rawURL string) string {
+	// Find the index of "api-version=" in the URL
+	apiVersionIndex := strings.Index(rawURL, "api-version=")
+
+	// If api-version is not found, return the original URL
+	if apiVersionIndex == -1 {
+		return rawURL
+	}
+
+	// Find the character that comes before "api-version="
+	// It could be either "?" (if it's the first parameter) or "&" (if it comes after other parameters)
+	separatorIndex := -1
+	if apiVersionIndex > 0 {
+		if rawURL[apiVersionIndex-1] == '?' {
+			separatorIndex = apiVersionIndex - 1
+		} else if rawURL[apiVersionIndex-1] == '&' {
+			separatorIndex = apiVersionIndex - 1
+		}
+	}
+
+	// If a separator was found, truncate the URL at that point
+	// this is to prevent additional query params from being included in the aggregated data on dashboards
+	if separatorIndex != -1 {
+		return rawURL[:separatorIndex]
+	}
+
+	return rawURL
 }
 
 func LogRequest(params LogRequestParams) {
-    var method, service, reqURL string
-    switch req := params.Request.(type) {
-    case *http.Request:
-        method = req.Method
-        service = req.Host
-        reqURL = req.URL.String()
+	var method, service, reqURL string
+	switch req := params.Request.(type) {
+	case *http.Request:
+		method = req.Method
+		service = req.Host
+		reqURL = req.URL.String()
 
-    case *azcorePolicy.Request:
-        method = req.Raw().Method
-        service = req.Raw().Host
-        reqURL = req.Raw().URL.String()
-    default:
-        return // Unknown request type, do nothing
-    }
+	case *azcorePolicy.Request:
+		method = req.Raw().Method
+		service = req.Raw().Host
+		reqURL = req.Raw().URL.String()
+	default:
+		return // Unknown request type, do nothing
+	}
 
-    parsedURL, parseErr := url.Parse(reqURL)
-    if parseErr != nil {
-        params.Logger.With(
-            "source", "ApiRequestLog",
-            "protocol", "REST",
-            "method_type", "unary",
-            "code", "na",
-            "component", "client",
-            "time_ms", "na",
-            "method", method,
-            "service", service,
-            "url", reqURL,
-            "error", parseErr.Error(),
-        ).Error("error parsing request URL")
-    } else {
-        reqURL = TrimURL(*parsedURL)
-    }
+	parsedURL, parseErr := url.Parse(reqURL)
+	if parseErr != nil {
+		params.Logger.With(
+			"source", "ApiRequestLog",
+			"protocol", "REST",
+			"method_type", "unary",
+			"code", "na",
+			"component", "client",
+			"time_ms", "na",
+			"method", method,
+			"service", service,
+			"url", reqURL,
+			"error", parseErr.Error(),
+		).Error("error parsing request URL")
+	} else {
+		reqURL = TrimURL(*parsedURL)
+	}
 
-    methodInfo := GetMethodInfo(method, reqURL)
-    latency := time.Since(params.StartTime).Milliseconds()
+	methodInfo := GetMethodInfo(method, reqURL)
+	latency := time.Since(params.StartTime).Milliseconds()
 
-    var headers map[string]string
-    if params.Response != nil {
-        headers = extractHeaders(params.Response.Header)
-    }
+	var headers map[string]string
+	if params.Response != nil {
+		headers = extractHeaders(params.Response.Header)
+	}
 
-    logEntry := params.Logger.With(
-        "source", "ApiRequestLog",
-        "protocol", "REST",
-        "method_type", "unary",
-        "component", "client",
-        "time_ms", latency,
-        "method", methodInfo,
-        "service", service,
-        "url", reqURL,
-        "headers", headers,
-    )
+	logEntry := params.Logger.With(
+		"source", "ApiRequestLog",
+		"protocol", "REST",
+		"method_type", "unary",
+		"component", "client",
+		"time_ms", latency,
+		"method", methodInfo,
+		"service", service,
+		"url", reqURL,
+		"headers", headers,
+	)
 
-    if params.Error != nil || params.Response == nil {
-        logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
-    } else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
-        logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
-    } else {
-        logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
-    }
+	if params.Error != nil || params.Response == nil {
+		logEntry.With("error", params.Error.Error(), "code", "na").Error("finished call")
+	} else if 200 <= params.Response.StatusCode && params.Response.StatusCode < 300 {
+		logEntry.With("error", "na", "code", params.Response.StatusCode).Info("finished call")
+	} else {
+		logEntry.With("error", params.Response.Status, "code", params.Response.StatusCode).Error("finished call")
+	}
 }
 
 func extractHeaders(header http.Header) map[string]string {
-    headers := make(map[string]string)
+	headers := make(map[string]string)
 
-    // List of headers to extract
-    headerKeys := []string{
-        common.RequestCorrelationIDHeader,
-        common.RequestAcsOperationIDHeader,
-        common.RequestARMClientRequestIDHeader,
-    }
+	// List of headers to extract
+	headerKeys := []string{
+		common.RequestCorrelationIDHeader,
+		common.RequestAcsOperationIDHeader,
+		common.RequestARMClientRequestIDHeader,
+	}
 
-    // Convert header keys to lowercase
-    lowerHeader := make(http.Header)
-    for key, values := range header {
-        lowerHeader[strings.ToLower(key)] = values
-    }
+	// Convert header keys to lowercase
+	lowerHeader := make(http.Header)
+	for key, values := range header {
+		lowerHeader[strings.ToLower(key)] = values
+	}
 
-    for _, key := range headerKeys {
-        lowerKey := strings.ToLower(key)
-        if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
-            headers[key] = values[0]
-        }
-    }
+	for _, key := range headerKeys {
+		lowerKey := strings.ToLower(key)
+		if values, ok := lowerHeader[lowerKey]; ok && len(values) > 0 {
+			headers[key] = values[0]
+		}
+	}
 
-    return headers
+	return headers
 }
 
 // ResponseWriter is a custom response writer that buffers the response body and tracks the status code.
 type ResponseWriter struct {
-    http.ResponseWriter
-    StatusCode int
-    Buf        *bytes.Buffer
+	http.ResponseWriter
+	StatusCode int
+	Buf        *bytes.Buffer
 }
 
 func NewResponseWriter(w http.ResponseWriter) *ResponseWriter {
-    return &ResponseWriter{
-        ResponseWriter: w,
-        Buf:            new(bytes.Buffer),
-    }
+	return &ResponseWriter{
+		ResponseWriter: w,
+		Buf:            new(bytes.Buffer),
+	}
 }
 
 func (w *ResponseWriter) WriteHeader(code int) {
-    w.StatusCode = code
-    w.ResponseWriter.WriteHeader(code)
+	w.StatusCode = code
+	w.ResponseWriter.WriteHeader(code)
 }
 
 func (w *ResponseWriter) Write(b []byte) (int, error) {
-    if w.StatusCode == 0 {
-        w.StatusCode = http.StatusOK
-    }
-    if w.StatusCode >= http.StatusBadRequest {
-        if w.Buf == nil {
-            w.Buf = new(bytes.Buffer)
-        }
-        // Write only if status code indicates error
-        w.Buf.Write(b)
-    }
-    return w.ResponseWriter.Write(b)
+	if w.StatusCode == 0 {
+		w.StatusCode = http.StatusOK
+	}
+	if w.StatusCode >= http.StatusBadRequest {
+		if w.Buf == nil {
+			w.Buf = new(bytes.Buffer)
+		}
+		// Write only if status code indicates error
+		w.Buf.Write(b)
+	}
+	return w.ResponseWriter.Write(b)
 }

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,16 +1,16 @@
 package logging
 
 import (
-	"bytes"
-	"log/slog"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
+    "bytes"
+    "log/slog"
+    "net/http"
+    "net/url"
+    "strings"
+    "time"
 
-	"github.com/Azure/aks-middleware/http/common"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+    "github.com/Azure/aks-middleware/http/common"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {

--- a/http/common/logging/logging.go
+++ b/http/common/logging/logging.go
@@ -1,16 +1,16 @@
 package logging
 
 import (
-    "bytes"
-    "log/slog"
-    "net/http"
-    "net/url"
-    "strings"
-    "time"
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
-    "github.com/Azure/aks-middleware/http/common"
-    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-    azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/aks-middleware/http/common"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorePolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 type LogRequestParams struct {
@@ -103,7 +103,7 @@ func LogRequest(params LogRequestParams) {
     default:
         return // Unknown request type, do nothing
     }
-
+    fullURL := reqURL
     parsedURL, parseErr := url.Parse(reqURL)
     if parseErr != nil {
         params.Logger.With(
@@ -115,7 +115,7 @@ func LogRequest(params LogRequestParams) {
             "time_ms", "na",
             "method", method,
             "service", service,
-            "url", reqURL,
+            "url", fullURL,
             "error", parseErr.Error(),
         ).Error("error parsing request URL")
     } else {
@@ -138,7 +138,7 @@ func LogRequest(params LogRequestParams) {
         "time_ms", latency,
         "method", methodInfo,
         "service", service,
-        "url", reqURL,
+        "url", fullURL,
         "headers", headers,
     )
 

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -135,4 +135,25 @@ var _ = Describe("LogRequest", func() {
 			Expect(logBuffer.String()).To(ContainSubstring(expected))
 		})
 	})
+
+	Context("when URL is not a valid resource ID and requires fallback", func() {
+		It("logs the URL with api-version and everything after removed", func() {
+			parsedURL, err := url.Parse("https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01")
+			Expect(err).To(BeNil())
+
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "GET", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+
+			logging.LogRequest(params)
+
+			// The URL should remove the query paramters for the method attribute
+			Expect(logBuffer.String()).To(ContainSubstring("GET https://example.com/api/nonResourcePath"))
+			Expect(logBuffer.String()).ToNot(ContainSubstring("GET https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01"))
+		})
+	})
 })

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -137,7 +137,7 @@ var _ = Describe("LogRequest", func() {
 	})
 
 	Context("when URL is not a valid resource ID and requires fallback", func() {
-		It("logs the URL with api-version and everything after removed", func() {
+		It("logs the trimmed URL that removes all query parameters", func() {
 			parsedURL, err := url.Parse("https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01")
 			Expect(err).To(BeNil())
 

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -1,160 +1,160 @@
 package logging_test
 
 import (
-    "bytes"
-    "context"
-    "log/slog"
-    "net/http"
-    "net/url"
-    "time"
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
 
-    "github.com/Azure/aks-middleware/http/common/logging"
-    "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-    . "github.com/onsi/ginkgo/v2"
-    . "github.com/onsi/gomega"
+	"github.com/Azure/aks-middleware/http/common/logging"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("LogRequest", func() {
-    var (
-        logger    *slog.Logger
-        logBuffer *bytes.Buffer
-    )
+	var (
+		logger    *slog.Logger
+		logBuffer *bytes.Buffer
+	)
 
-    BeforeEach(func() {
-        logBuffer = &bytes.Buffer{}
-        logger = slog.New(slog.NewJSONHandler(logBuffer, nil))
-    })
+	BeforeEach(func() {
+		logBuffer = &bytes.Buffer{}
+		logger = slog.New(slog.NewJSONHandler(logBuffer, nil))
+	})
 
-    AfterEach(func() {
-        logBuffer.Reset()
-    })
+	AfterEach(func() {
+		logBuffer.Reset()
+	})
 
-    Context("when method is GET and URL has nested resource type", func() {
-        It("logs the correct method info for a READ operation", func() {
-            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name?api-version=version")
-            Expect(err).To(BeNil())
+	Context("when method is GET and URL has nested resource type", func() {
+		It("logs the correct method info for a READ operation", func() {
+			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name?api-version=version")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   &http.Request{Method: "GET", URL: parsedURL},
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
-            expected := "GET storageaccounts - READ"
-            logging.LogRequest(params)
-            Expect(logBuffer.String()).To(ContainSubstring(expected))
-        })
-    })
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "GET", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+			expected := "GET storageaccounts - READ"
+			logging.LogRequest(params)
+			Expect(logBuffer.String()).To(ContainSubstring(expected))
+		})
+	})
 
-    Context("when method is GET and URL has top-level resource type", func() {
-        It("logs the correct method info for a LIST operation", func() {
-            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups?api-version=version")
-            Expect(err).To(BeNil())
+	Context("when method is GET and URL has top-level resource type", func() {
+		It("logs the correct method info for a LIST operation", func() {
+			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups?api-version=version")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   &http.Request{Method: "GET", URL: parsedURL},
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
-            expected := "GET resourcegroups - LIST"
-            logging.LogRequest(params)
-            Expect(logBuffer.String()).To(ContainSubstring(expected))
-        })
-    })
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "GET", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+			expected := "GET resourcegroups - LIST"
+			logging.LogRequest(params)
+			Expect(logBuffer.String()).To(ContainSubstring(expected))
+		})
+	})
 
-    Context("when method is not GET", func() {
-        It("logs the correct method info without operation type", func() {
-            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
-            Expect(err).To(BeNil())
+	Context("when method is not GET", func() {
+		It("logs the correct method info without operation type", func() {
+			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   &http.Request{Method: "POST", URL: parsedURL},
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
-            expected := "POST storageaccounts"
-            logging.LogRequest(params)
-            Expect(logBuffer.String()).To(ContainSubstring(expected))
-        })
-    })
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "POST", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+			expected := "POST storageaccounts"
+			logging.LogRequest(params)
+			Expect(logBuffer.String()).To(ContainSubstring(expected))
+		})
+	})
 
-    Context("when sending an azcore policy req", func() {
-        It("logs the correct method info without operation type", func() {
-            req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
-            Expect(err).To(BeNil())
+	Context("when sending an azcore policy req", func() {
+		It("logs the correct method info without operation type", func() {
+			req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   req,
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
-            expected := "POST storageaccounts"
-            logging.LogRequest(params)
-            Expect(logBuffer.String()).To(ContainSubstring(expected))
-        })
-    })
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   req,
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+			expected := "POST storageaccounts"
+			logging.LogRequest(params)
+			Expect(logBuffer.String()).To(ContainSubstring(expected))
+		})
+	})
 
-    Context("when using a custom resource type", func() {
-        It("logs the correct method info", func() {
-            parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
-            Expect(err).To(BeNil())
+	Context("when using a custom resource type", func() {
+		It("logs the correct method info", func() {
+			parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   &http.Request{Method: "GET", URL: parsedURL},
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
-            expected := "GET nodebootstrapping - LIST"
-            logging.LogRequest(params)
-            Expect(logBuffer.String()).To(ContainSubstring(expected))
-        })
-    })
-    Context("when there are multiple query parameters", func() {
-        It("logs the correct method with the entire URL", func() {
-            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version&param1=value1&param2=value2")
-            Expect(err).To(BeNil())
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "GET", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+			expected := "GET nodebootstrapping - LIST"
+			logging.LogRequest(params)
+			Expect(logBuffer.String()).To(ContainSubstring(expected))
+		})
+	})
+	Context("when there are multiple query parameters", func() {
+		It("logs the correct method with the entire URL", func() {
+			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version&param1=value1&param2=value2")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   &http.Request{Method: "GET", URL: parsedURL},
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
-            expected := "GET storageaccounts - LIST"
-            logging.LogRequest(params)
-            Expect(logBuffer.String()).To(ContainSubstring(expected))
-        })
-    })
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "GET", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
+			expected := "GET storageaccounts - LIST"
+			logging.LogRequest(params)
+			Expect(logBuffer.String()).To(ContainSubstring(expected))
+		})
+	})
 
-    Context("when URL is not a valid resource ID and requires fallback", func() {
-        It("logs the URL with api-version and everything after removed", func() {
-            parsedURL, err := url.Parse("https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01")
-            Expect(err).To(BeNil())
+	Context("when URL is not a valid resource ID and requires fallback", func() {
+		It("logs the URL with api-version and everything after removed", func() {
+			parsedURL, err := url.Parse("https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01")
+			Expect(err).To(BeNil())
 
-            params := logging.LogRequestParams{
-                Logger:    logger,
-                StartTime: time.Now(),
-                Request:   &http.Request{Method: "GET", URL: parsedURL},
-                Response:  &http.Response{StatusCode: 200},
-                Error:     nil,
-            }
+			params := logging.LogRequestParams{
+				Logger:    logger,
+				StartTime: time.Now(),
+				Request:   &http.Request{Method: "GET", URL: parsedURL},
+				Response:  &http.Response{StatusCode: 200},
+				Error:     nil,
+			}
 
-            logging.LogRequest(params)
+			logging.LogRequest(params)
 
-            // The URL should remove the query paramters for the method attribute
-            Expect(logBuffer.String()).To(ContainSubstring("GET https://example.com/api/nonResourcePath"))
-            // The value for the method attribut key should not contain the api-version or other query parameters
-            Expect(logBuffer.String()).ToNot(ContainSubstring("GET https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01"))
-        })
-    })
+			// The URL should remove the query paramters for the method attribute
+			Expect(logBuffer.String()).To(ContainSubstring("GET https://example.com/api/nonResourcePath"))
+			// The value for the method attribut key should not contain the api-version or other query parameters
+			Expect(logBuffer.String()).ToNot(ContainSubstring("GET https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01"))
+		})
+	})
 })

--- a/http/common/logging/logging_test.go
+++ b/http/common/logging/logging_test.go
@@ -1,159 +1,160 @@
 package logging_test
 
 import (
-	"bytes"
-	"context"
-	"log/slog"
-	"net/http"
-	"net/url"
-	"time"
+    "bytes"
+    "context"
+    "log/slog"
+    "net/http"
+    "net/url"
+    "time"
 
-	"github.com/Azure/aks-middleware/http/common/logging"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+    "github.com/Azure/aks-middleware/http/common/logging"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+    . "github.com/onsi/ginkgo/v2"
+    . "github.com/onsi/gomega"
 )
 
 var _ = Describe("LogRequest", func() {
-	var (
-		logger    *slog.Logger
-		logBuffer *bytes.Buffer
-	)
+    var (
+        logger    *slog.Logger
+        logBuffer *bytes.Buffer
+    )
 
-	BeforeEach(func() {
-		logBuffer = &bytes.Buffer{}
-		logger = slog.New(slog.NewJSONHandler(logBuffer, nil))
-	})
+    BeforeEach(func() {
+        logBuffer = &bytes.Buffer{}
+        logger = slog.New(slog.NewJSONHandler(logBuffer, nil))
+    })
 
-	AfterEach(func() {
-		logBuffer.Reset()
-	})
+    AfterEach(func() {
+        logBuffer.Reset()
+    })
 
-	Context("when method is GET and URL has nested resource type", func() {
-		It("logs the correct method info for a READ operation", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name?api-version=version")
-			Expect(err).To(BeNil())
+    Context("when method is GET and URL has nested resource type", func() {
+        It("logs the correct method info for a READ operation", func() {
+            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts/account_name?api-version=version")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "GET storageaccounts - READ"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   &http.Request{Method: "GET", URL: parsedURL},
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
+            expected := "GET storageaccounts - READ"
+            logging.LogRequest(params)
+            Expect(logBuffer.String()).To(ContainSubstring(expected))
+        })
+    })
 
-	Context("when method is GET and URL has top-level resource type", func() {
-		It("logs the correct method info for a LIST operation", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups?api-version=version")
-			Expect(err).To(BeNil())
+    Context("when method is GET and URL has top-level resource type", func() {
+        It("logs the correct method info for a LIST operation", func() {
+            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups?api-version=version")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "GET resourcegroups - LIST"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   &http.Request{Method: "GET", URL: parsedURL},
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
+            expected := "GET resourcegroups - LIST"
+            logging.LogRequest(params)
+            Expect(logBuffer.String()).To(ContainSubstring(expected))
+        })
+    })
 
-	Context("when method is not GET", func() {
-		It("logs the correct method info without operation type", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
-			Expect(err).To(BeNil())
+    Context("when method is not GET", func() {
+        It("logs the correct method info without operation type", func() {
+            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "POST", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "POST storageaccounts"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   &http.Request{Method: "POST", URL: parsedURL},
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
+            expected := "POST storageaccounts"
+            logging.LogRequest(params)
+            Expect(logBuffer.String()).To(ContainSubstring(expected))
+        })
+    })
 
-	Context("when sending an azcore policy req", func() {
-		It("logs the correct method info without operation type", func() {
-			req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
-			Expect(err).To(BeNil())
+    Context("when sending an azcore policy req", func() {
+        It("logs the correct method info without operation type", func() {
+            req, err := runtime.NewRequest(context.Background(), http.MethodPost, "https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   req,
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "POST storageaccounts"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   req,
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
+            expected := "POST storageaccounts"
+            logging.LogRequest(params)
+            Expect(logBuffer.String()).To(ContainSubstring(expected))
+        })
+    })
 
-	Context("when using a custom resource type", func() {
-		It("logs the correct method info", func() {
-			parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
-			Expect(err).To(BeNil())
+    Context("when using a custom resource type", func() {
+        It("logs the correct method info", func() {
+            parsedURL, err := url.Parse("http://nodeprovisioner-svc.nodeprovisioner.svc.cluster.local:80/subscriptions/26ad903f-2330-429d-8389-864ac35c4350/resourceGroups/e2erg-tomabraebld114261747-nRi/providers/Microsoft.ContainerService/managedclusters/e2eaks-Sfs/nodeBootstrapping")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "GET nodebootstrapping - LIST"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
-	Context("when there are multiple query parameters", func() {
-		It("logs the correct method with the entire URL", func() {
-			parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version&param1=value1&param2=value2")
-			Expect(err).To(BeNil())
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   &http.Request{Method: "GET", URL: parsedURL},
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
+            expected := "GET nodebootstrapping - LIST"
+            logging.LogRequest(params)
+            Expect(logBuffer.String()).To(ContainSubstring(expected))
+        })
+    })
+    Context("when there are multiple query parameters", func() {
+        It("logs the correct method with the entire URL", func() {
+            parsedURL, err := url.Parse("https://management.azure.com/subscriptions/sub_id/resourceGroups/rg_name/providers/Microsoft.Storage/storageAccounts?api-version=version&param1=value1&param2=value2")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
-			expected := "GET storageaccounts - LIST"
-			logging.LogRequest(params)
-			Expect(logBuffer.String()).To(ContainSubstring(expected))
-		})
-	})
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   &http.Request{Method: "GET", URL: parsedURL},
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
+            expected := "GET storageaccounts - LIST"
+            logging.LogRequest(params)
+            Expect(logBuffer.String()).To(ContainSubstring(expected))
+        })
+    })
 
-	Context("when URL is not a valid resource ID and requires fallback", func() {
-		It("logs the URL with api-version and everything after removed", func() {
-			parsedURL, err := url.Parse("https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01")
-			Expect(err).To(BeNil())
+    Context("when URL is not a valid resource ID and requires fallback", func() {
+        It("logs the URL with api-version and everything after removed", func() {
+            parsedURL, err := url.Parse("https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01")
+            Expect(err).To(BeNil())
 
-			params := logging.LogRequestParams{
-				Logger:    logger,
-				StartTime: time.Now(),
-				Request:   &http.Request{Method: "GET", URL: parsedURL},
-				Response:  &http.Response{StatusCode: 200},
-				Error:     nil,
-			}
+            params := logging.LogRequestParams{
+                Logger:    logger,
+                StartTime: time.Now(),
+                Request:   &http.Request{Method: "GET", URL: parsedURL},
+                Response:  &http.Response{StatusCode: 200},
+                Error:     nil,
+            }
 
-			logging.LogRequest(params)
+            logging.LogRequest(params)
 
-			// The URL should remove the query paramters for the method attribute
-			Expect(logBuffer.String()).To(ContainSubstring("GET https://example.com/api/nonResourcePath"))
-			Expect(logBuffer.String()).ToNot(ContainSubstring("GET https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01"))
-		})
-	})
+            // The URL should remove the query paramters for the method attribute
+            Expect(logBuffer.String()).To(ContainSubstring("GET https://example.com/api/nonResourcePath"))
+            // The value for the method attribut key should not contain the api-version or other query parameters
+            Expect(logBuffer.String()).ToNot(ContainSubstring("GET https://example.com/api/nonResourcePath?param1=value1&api-version=2023-01-01"))
+        })
+    })
 })


### PR DESCRIPTION
grab operationID and correlationID from metadata in context and include that information in headers col of grpc ApiRequestLog

http common log changes to ensure method attribute value does not contain `api-version` or other query parameters so that dashboard is not cluttered with various versions/params